### PR TITLE
[bugfix/issues/1] Generation of recursive data fails

### DIFF
--- a/arbitrary/ptr.go
+++ b/arbitrary/ptr.go
@@ -5,33 +5,32 @@ import (
 )
 
 type Ptr struct {
-	IsNull bool
-	Type   Type
+	Type        reflect.Type
+	ElementType Type
 }
 
 func (ptr Ptr) Shrink() []Type {
-	if ptr.IsNull {
+	if ptr.ElementType == nil {
 		return nil
 	}
 
-	shrinked := ptr.Type.Shrink()
-	result := make([]Type, len(shrinked), len(shrinked))
+	shrinked := ptr.ElementType.Shrink()
+	result := make([]Type, len(shrinked))
 	for index, t := range shrinked {
 		result[index] = Ptr{
-			IsNull: false,
-			Type:   t,
+			ElementType: t,
 		}
 	}
 	return append(result, Ptr{
-		IsNull: true,
+		ElementType: nil,
 	})
 }
 
 func (ptr Ptr) Value() reflect.Value {
-	if ptr.IsNull {
-		return reflect.Zero(reflect.PtrTo(ptr.Type.Value().Type()))
+	if ptr.ElementType == nil {
+		return reflect.Zero(ptr.Type)
 	}
-	val := reflect.New(ptr.Type.Value().Type())
-	val.Elem().Set(ptr.Type.Value())
+	val := reflect.New(ptr.Type.Elem())
+	val.Elem().Set(ptr.ElementType.Value())
 	return val
 }

--- a/check.go
+++ b/check.go
@@ -26,13 +26,13 @@ func Check(t *testing.T, property property, config ...Config) {
 	}
 	r := rand.New(rand.NewSource(configuration.Seed))
 
-	run, err := property()
+	run, err := property(r)
 	if err != nil {
 		t.Fatalf("failed to run property. %s", err)
 	}
 
 	for i := int64(0); i < configuration.Iterations; i++ {
-		if err := run(r); err != nil {
+		if err := run(); err != nil {
 			t.Fatalf("\nCheck failed with seed: %d. \n%s", configuration.Seed, err)
 		}
 	}

--- a/generator/any.go
+++ b/generator/any.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 )
 
@@ -10,7 +11,7 @@ import (
 // default generator for it's reflect.Kind will be returned. Default generator for any type is
 // a generator with default constraints. Error will be thrown if target type is not supported.
 func Any() Arbitrary {
-	return func(target reflect.Type) (Generator, error) {
+	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
 		var generator Arbitrary
 		switch target.Kind() {
 		case reflect.Array:
@@ -57,6 +58,6 @@ func Any() Arbitrary {
 			return nil, fmt.Errorf("no support for generating values for kind: %s", target.Kind())
 		}
 
-		return generator(target)
+		return generator(target, r)
 	}
 }

--- a/generator/array.go
+++ b/generator/array.go
@@ -13,11 +13,11 @@ import (
 // by Generator's target. Error is returned If target's kind is not reflect.Array
 // or if Generator creation for array's elements fails.
 func Array(element Arbitrary) Arbitrary {
-	return func(target reflect.Type) (Generator, error) {
+	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
 		if target.Kind() != reflect.Array {
 			return nil, fmt.Errorf("target arbitrary's kind must be Array. Got: %s", target.Kind())
 		}
-		generate, err := element(target.Elem())
+		generate, err := element(target.Elem(), r)
 		if err != nil {
 			return nil, fmt.Errorf("failed to crete generator. %s", err)
 		}

--- a/generator/bool.go
+++ b/generator/bool.go
@@ -7,7 +7,7 @@ func Bool() Arbitrary {
 	return Int64(constraints.Int64{
 		Min: 0,
 		Max: 1,
-	}).Map(func(n int64) (bool, error) {
-		return n == 0, nil
+	}).Map(func(n int64) bool {
+		return n == 0
 	})
 }

--- a/generator/func.go
+++ b/generator/func.go
@@ -24,7 +24,7 @@ func hash(values []reflect.Value) []int64 {
 // variadic parameter doesn't match the number of target's function outputs, any
 // of the output Arbitraries fails to create it's generator.
 func Func(outputs ...Arbitrary) Arbitrary {
-	return func(target reflect.Type) (Generator, error) {
+	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
 		if target.Kind() != reflect.Func {
 			return nil, fmt.Errorf("funcPtr must be a pointer to function")
 		}
@@ -33,13 +33,13 @@ func Func(outputs ...Arbitrary) Arbitrary {
 		}
 		generators := make([]Generator, len(outputs))
 		for index, arb := range outputs {
-			generator, err := arb(target.Out(index))
+			generator, err := arb(target.Out(index), r)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create generator for output[%d]. %s", index, err)
 			}
 			generators[index] = generator
 		}
-		return func(r *rand.Rand) arbitrary.Type {
+		return func(_ *rand.Rand) arbitrary.Type {
 			return arbitrary.Func{
 				Fn: reflect.MakeFunc(target, func(inputs []reflect.Value) []reflect.Value {
 					seeds := hash(inputs)

--- a/generator/int.go
+++ b/generator/int.go
@@ -21,7 +21,7 @@ func Int64(limits ...constraints.Int64) Arbitrary {
 	if len(limits) > 0 {
 		constraint = limits[0]
 	}
-	return func(target reflect.Type) (Generator, error) {
+	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
 		if target.Kind() != reflect.Int64 {
 			return nil, fmt.Errorf("target arbitrary's kind must be Int64. Got: %s", target.Kind())
 		}

--- a/generator/map.go
+++ b/generator/map.go
@@ -17,15 +17,15 @@ import (
 // if target's reflect.Kind is not Map, fails to create map's key and value
 // Generator or if creation of map's size fails.
 func Map(key, value Arbitrary, limits ...constraints.Length) Arbitrary {
-	return func(target reflect.Type) (Generator, error) {
+	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
 		constraint := constraints.LengthDefault()
 		if len(limits) != 0 {
 			constraint = limits[0]
 		}
 
-		generateKey, keyErr := key(target.Key())
-		generateValue, valueErr := value(target.Elem())
-		generateSize, sizeErr := Int(constraints.Int(constraint))(reflect.TypeOf(int(0)))
+		generateKey, keyErr := key(target.Key(), r)
+		generateValue, valueErr := value(target.Elem(), r)
+		generateSize, sizeErr := Int(constraints.Int(constraint))(reflect.TypeOf(int(0)), r)
 
 		switch {
 		case keyErr != nil:

--- a/generator/one-of.go
+++ b/generator/one-of.go
@@ -1,0 +1,22 @@
+package generator
+
+import (
+	"math/rand"
+	"reflect"
+)
+
+// OneOf is Arbitrary that will create Generator for one of the passed
+// arbitraries.
+func OneOf(first Arbitrary, other ...Arbitrary) Arbitrary {
+	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
+		arbitraries := append([]Arbitrary{first}, other...)
+		arb := arbitraries[r.Intn(len(arbitraries))]
+
+		gen, err := arb(target, r)
+		if err != nil {
+			return nil, err
+		}
+
+		return gen, nil
+	}
+}

--- a/generator/ptr.go
+++ b/generator/ptr.go
@@ -8,33 +8,50 @@ import (
 	"github.com/steffnova/go-check/arbitrary"
 )
 
-// Ptr is Arbitrary that creates pointer Generator. Type to which pointer
-// points is defined by arb paramter. Arbitrary fails to create pointer
-// Generator if target's reflect.Kind is not Ptr, or arb fails to generate
-// Generator for value pointer points to.
+// Ptr is Arbitrary that creates pointer Generator. Generator will return
+// either valid or invalid (nil) pointer for targetn's type. Error is returned
+// if target's reflect.Kind is not Ptr, or creation of arb's Generator fails.
 func Ptr(arb Arbitrary) Arbitrary {
-	return func(target reflect.Type) (Generator, error) {
+	return OneOf(PtrInvalid(), PtrValid(arb))
+}
+
+// PtrInvalid is Arbitrary that creates pointer Generator. Generator will
+// always return nil pointer for target's type. Error is returned if target's
+// reflect.Kind is not Ptr.
+func PtrInvalid() Arbitrary {
+	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
 		if target.Kind() != reflect.Ptr {
 			return nil, fmt.Errorf("target's kind must be Ptr. Got: %s", target.Kind())
 		}
-		generateValue, err := arb(target.Elem())
+
+		return func(rand *rand.Rand) arbitrary.Type {
+			return arbitrary.Ptr{
+				ElementType: nil,
+				Type:        target,
+			}
+		}, nil
+	}
+}
+
+// PtrValid is Arbitrary that creates pointer Generator. Generator will
+// always return non-nil pointer for target's type. Error is returned
+// if target's reflect.Kind is not Ptr, or creation of arb's Generator
+// fails.
+func PtrValid(arb Arbitrary) Arbitrary {
+	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
+		if target.Kind() != reflect.Ptr {
+			return nil, fmt.Errorf("target's kind must be Ptr. Got: %s", target.Kind())
+		}
+
+		generateValue, err := arb(target.Elem(), r)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create base generator. %s", err)
 		}
-		generateBool, err := Bool()(reflect.TypeOf(false))
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate bool generator. %s", err)
-		}
 
 		return func(rand *rand.Rand) arbitrary.Type {
-			isNull := generateBool(rand).Value().Bool()
-			t := arbitrary.Type(nil)
-			if !isNull {
-				t = generateValue(rand)
-			}
 			return arbitrary.Ptr{
-				IsNull: isNull,
-				Type:   t,
+				Type:        target,
+				ElementType: generateValue(rand),
 			}
 		}, nil
 	}

--- a/generator/slice.go
+++ b/generator/slice.go
@@ -16,7 +16,7 @@ import (
 // if target's reflect.Kind is not Slice, if creation of Generator for slice's elements
 // fails or creation of Generator for slice's size fail.
 func Slice(element Arbitrary, limits ...constraints.Length) Arbitrary {
-	return func(target reflect.Type) (Generator, error) {
+	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
 		constraint := constraints.LengthDefault()
 		if len(limits) != 0 {
 			constraint = limits[0]
@@ -25,12 +25,12 @@ func Slice(element Arbitrary, limits ...constraints.Length) Arbitrary {
 			return nil, fmt.Errorf("targets kind must be Slice. Got: %s", target.Kind())
 		}
 
-		generateElement, err := element(target.Elem())
+		generateElement, err := element(target.Elem(), r)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create generator for slice elements: %s", err)
 		}
 
-		generateSize, err := Int(constraints.Int(constraint))(reflect.TypeOf(int(0)))
+		generateSize, err := Int(constraints.Int(constraint))(reflect.TypeOf(int(0)), r)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create slice length generator: %s", err)
 		}

--- a/generator/struct.go
+++ b/generator/struct.go
@@ -18,7 +18,7 @@ func Struct(fieldArbitraries ...map[string]Arbitrary) Arbitrary {
 		fieldGenerators = fieldArbitraries[0]
 	}
 
-	return func(target reflect.Type) (Generator, error) {
+	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
 		if target.Kind() != reflect.Struct {
 			return nil, fmt.Errorf("target must be a struct")
 		}
@@ -29,9 +29,9 @@ func Struct(fieldArbitraries ...map[string]Arbitrary) Arbitrary {
 			if !exists {
 				generator = Any()
 			}
-			generate, err := generator(field.Type)
+			generate, err := generator(field.Type, r)
 			if err != nil {
-				return nil, fmt.Errorf("failed to create generator for field: %s", field.Name)
+				return nil, fmt.Errorf("failed to create generator for field: %s. %s", field.Name, err)
 			}
 			generators[index] = generate
 		}

--- a/generator/uint.go
+++ b/generator/uint.go
@@ -21,7 +21,7 @@ func Uint64(limits ...constraints.Uint64) Arbitrary {
 	if len(limits) > 0 {
 		constraint = limits[0]
 	}
-	return func(target reflect.Type) (Generator, error) {
+	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
 		if target.Kind() != reflect.Uint64 {
 			return nil, fmt.Errorf("target arbitrary's kind must be Uint64. Got: %s", target.Kind())
 		}
@@ -37,7 +37,7 @@ func Uint64(limits ...constraints.Uint64) Arbitrary {
 			diff := big.NewInt(0).Sub(max, min)
 			diff = diff.Add(diff, big.NewInt(1))
 
-			n := diff.Rand(rand, diff)
+			n := diff.Rand(r, diff)
 			n = n.Add(diff, min)
 
 			return arbitrary.Uint64{


### PR DESCRIPTION
[Problem]
Generation of recursive data structure fails because of the stack overflow.
Structure that has a property with pointer to itself is one of the examples.

[Solution]
The issue is that generator.Ptr(arb Arbitrary) will enter in a recursive
loop as it tries to create Generator for arb. Creation of arn Generator
is initated whether the pointer should nil or not.

In order to avoid this issue, randomness of arb's generator creation
should be done before Generator for Ptr is created. In order to do so
Arbitrary signature needs to be changes, as Arbitrary needs to have an
access to *rand.Rand to implement randomness.

Arbitrary signature is now: type Arbitrary(target reflect.Type, r *rand.Rand) (Generator, error)

This also allows a implementation of generator.OneOf. Two other arbitraries
in generator package have been added: generator.PtrInvalid, generator.PtrValid.

Closes #1