### PR TITLE
[feature/issues/9] Abastract rand.Rand with Random interface

### DIFF
--- a/check.go
+++ b/check.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	// "github.com/steffnova/go-check/property"
 	"math/rand"
 	"testing"
 	"time"
@@ -24,9 +23,12 @@ func Check(t *testing.T, property property, config ...Config) {
 	if len(config) > 0 {
 		configuration = config[0]
 	}
-	r := rand.New(rand.NewSource(configuration.Seed))
 
-	run, err := property(r)
+	random := rng{
+		Rand: rand.New(rand.NewSource(configuration.Seed)),
+	}
+
+	run, err := property(random)
 	if err != nil {
 		t.Fatalf("failed to run property. %s", err)
 	}

--- a/generator/any.go
+++ b/generator/any.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 )
 
@@ -11,7 +10,7 @@ import (
 // default generator for it's reflect.Kind will be returned. Default generator for any type is
 // a generator with default constraints. Error will be thrown if target type is not supported.
 func Any() Arbitrary {
-	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
+	return func(target reflect.Type, r Random) (Generator, error) {
 		var generator Arbitrary
 		switch target.Kind() {
 		case reflect.Array:
@@ -58,6 +57,6 @@ func Any() Arbitrary {
 			return nil, fmt.Errorf("no support for generating values for kind: %s", target.Kind())
 		}
 
-		return generator(target, r)
+		return generator(target, r.Split())
 	}
 }

--- a/generator/arbitrary.go
+++ b/generator/arbitrary.go
@@ -2,26 +2,24 @@ package generator
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 
 	"github.com/steffnova/go-check/arbitrary"
 )
 
-// Generator generates random arbitrary.Type using pseudo-random
-// number generator specified by rand parameter.
-type Generator func(rand *rand.Rand) arbitrary.Type
+// Generator generates random arbitrary.Type
+type Generator func() arbitrary.Type
 
-// Arbitrary is Generator creator. It tries to create Generator
-// for type specified by target parameter.
-type Arbitrary func(target reflect.Type, r *rand.Rand) (Generator, error)
+// Arbitrary is Generator creator. It tries to create Generator for type specified
+// by target parameter with provided Random instance as r parameter.
+type Arbitrary func(target reflect.Type, r Random) (Generator, error)
 
 // Map maps receiver Arbitrary (arb) to a new Arbitrary using mapper. Mapper must be a
 // function that has one input and one output. Mappers's input type must satisfy
 // target's type. Mapper's output defines the Generator type created by mapped
 // Arbitrary.
 func (arb Arbitrary) Map(mapper interface{}) Arbitrary {
-	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
+	return func(target reflect.Type, r Random) (Generator, error) {
 		val := reflect.ValueOf(mapper)
 		switch {
 		case val.Kind() != reflect.Func:
@@ -32,15 +30,15 @@ func (arb Arbitrary) Map(mapper interface{}) Arbitrary {
 			return nil, fmt.Errorf("mapper must have 1 input value")
 		}
 
-		generateMappedValue, err := arb(val.Type().In(0), r)
+		generateMappedValue, err := arb(val.Type().In(0), r.Split())
 		switch {
 		case err != nil:
 			return nil, fmt.Errorf("failed to create base generator. %s", err)
 		case val.Type().Out(0).Kind() != target.Kind():
 			return nil, fmt.Errorf("mappers output parameter's kind must match target's kind")
 		default:
-			return func(rand *rand.Rand) arbitrary.Type {
-				arbType := generateMappedValue(rand)
+			return func() arbitrary.Type {
+				arbType := generateMappedValue()
 				outputs := reflect.ValueOf(mapper).Call([]reflect.Value{arbType.Value()})
 				return arbitrary.Mapped{
 					Base:   arbType,
@@ -60,8 +58,8 @@ func (arb Arbitrary) Map(mapper interface{}) Arbitrary {
 // NOTE: This can highly impact Generator's time to generate arbitrary.Type as it will
 // try to generate target's values unitl predicate is satisfied.
 func (arb Arbitrary) Filter(predicate interface{}) Arbitrary {
-	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
-		generate, err := arb(target, r)
+	return func(target reflect.Type, r Random) (Generator, error) {
+		generate, err := arb(target, r.Split())
 		switch val := reflect.ValueOf(predicate); {
 		case err != nil:
 			return nil, fmt.Errorf("failed to create base generator. %s", err)
@@ -75,9 +73,9 @@ func (arb Arbitrary) Filter(predicate interface{}) Arbitrary {
 			return nil, fmt.Errorf("predicate must have bool as a output value")
 		}
 
-		return func(rand *rand.Rand) arbitrary.Type {
+		return func() arbitrary.Type {
 			for {
-				arbType := generate(rand)
+				arbType := generate()
 				outputs := reflect.ValueOf(predicate).Call([]reflect.Value{arbType.Value()})
 				if outputs[0].Bool() {
 					return arbType

--- a/generator/array.go
+++ b/generator/array.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 
 	"github.com/steffnova/go-check/arbitrary"
@@ -13,19 +12,19 @@ import (
 // by Generator's target. Error is returned If target's kind is not reflect.Array
 // or if Generator creation for array's elements fails.
 func Array(element Arbitrary) Arbitrary {
-	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
+	return func(target reflect.Type, r Random) (Generator, error) {
 		if target.Kind() != reflect.Array {
 			return nil, fmt.Errorf("target arbitrary's kind must be Array. Got: %s", target.Kind())
 		}
-		generate, err := element(target.Elem(), r)
+		generate, err := element(target.Elem(), r.Split())
 		if err != nil {
 			return nil, fmt.Errorf("failed to crete generator. %s", err)
 		}
 
-		return func(rand *rand.Rand) arbitrary.Type {
+		return func() arbitrary.Type {
 			val := reflect.New(reflect.ArrayOf(target.Len(), target.Elem())).Elem()
 			for index := 0; index < target.Len(); index++ {
-				val.Index(index).Set(generate(rand).Value())
+				val.Index(index).Set(generate().Value())
 			}
 
 			return arbitrary.Array{

--- a/generator/int.go
+++ b/generator/int.go
@@ -2,8 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"math/big"
-	"math/rand"
 	"reflect"
 
 	"github.com/steffnova/go-check/arbitrary"
@@ -21,22 +19,14 @@ func Int64(limits ...constraints.Int64) Arbitrary {
 	if len(limits) > 0 {
 		constraint = limits[0]
 	}
-	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
+	return func(target reflect.Type, r Random) (Generator, error) {
 		if target.Kind() != reflect.Int64 {
 			return nil, fmt.Errorf("target arbitrary's kind must be Int64. Got: %s", target.Kind())
 		}
-		return func(rand *rand.Rand) arbitrary.Type {
-			max := big.NewInt(int64(constraint.Max))
-			min := big.NewInt(int64(constraint.Min))
-
-			val := big.NewInt(0).Sub(max, min)
-			val = big.NewInt(0).Add(val, big.NewInt(1))
-			val = val.Rand(rand, val)
-			val = val.Add(val, min)
-
+		return func() arbitrary.Type {
 			return arbitrary.Int64{
 				Constraint: constraint,
-				N:          val.Int64(),
+				N:          r.Int64(constraint.Min, constraint.Max),
 			}
 		}, nil
 	}

--- a/generator/one-of.go
+++ b/generator/one-of.go
@@ -1,18 +1,19 @@
 package generator
 
 import (
-	"math/rand"
 	"reflect"
 )
 
 // OneOf is Arbitrary that will create Generator for one of the passed
 // arbitraries.
 func OneOf(first Arbitrary, other ...Arbitrary) Arbitrary {
-	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
+	return func(target reflect.Type, r Random) (Generator, error) {
 		arbitraries := append([]Arbitrary{first}, other...)
-		arb := arbitraries[r.Intn(len(arbitraries))]
 
-		gen, err := arb(target, r)
+		index := int(r.Int64(0, int64(len(arbitraries)-1)))
+		arb := arbitraries[index]
+
+		gen, err := arb(target, r.Split())
 		if err != nil {
 			return nil, err
 		}

--- a/generator/ptr.go
+++ b/generator/ptr.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 
 	"github.com/steffnova/go-check/arbitrary"
@@ -19,12 +18,12 @@ func Ptr(arb Arbitrary) Arbitrary {
 // always return nil pointer for target's type. Error is returned if target's
 // reflect.Kind is not Ptr.
 func PtrInvalid() Arbitrary {
-	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
+	return func(target reflect.Type, r Random) (Generator, error) {
 		if target.Kind() != reflect.Ptr {
 			return nil, fmt.Errorf("target's kind must be Ptr. Got: %s", target.Kind())
 		}
 
-		return func(rand *rand.Rand) arbitrary.Type {
+		return func() arbitrary.Type {
 			return arbitrary.Ptr{
 				ElementType: nil,
 				Type:        target,
@@ -38,20 +37,20 @@ func PtrInvalid() Arbitrary {
 // if target's reflect.Kind is not Ptr, or creation of arb's Generator
 // fails.
 func PtrValid(arb Arbitrary) Arbitrary {
-	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
+	return func(target reflect.Type, r Random) (Generator, error) {
 		if target.Kind() != reflect.Ptr {
 			return nil, fmt.Errorf("target's kind must be Ptr. Got: %s", target.Kind())
 		}
 
-		generateValue, err := arb(target.Elem(), r)
+		generateValue, err := arb(target.Elem(), r.Split())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create base generator. %s", err)
 		}
 
-		return func(rand *rand.Rand) arbitrary.Type {
+		return func() arbitrary.Type {
 			return arbitrary.Ptr{
 				Type:        target,
-				ElementType: generateValue(rand),
+				ElementType: generateValue(),
 			}
 		}, nil
 	}

--- a/generator/random.go
+++ b/generator/random.go
@@ -1,0 +1,17 @@
+package generator
+
+// Random is an interface for random number generation
+type Random interface {
+	// Int64 generates random int64 in specifed range [min, max] (inclusive)
+	Int64(min, max int64) int64
+
+	// Uint64 generate random uint64 in specified range [min, max] (inclusive)
+	Uint64(min, max uint64) uint64
+
+	// Split returns new Random that can be used idenpendently of original. Random
+	// returned by Split can have it's seed changed without affecting the original
+	Split() Random
+
+	// Seed seeds Random with seed value
+	Seed(seed int64)
+}

--- a/generator/string.go
+++ b/generator/string.go
@@ -11,7 +11,7 @@ import (
 // fails.
 func String(limits ...constraints.String) Arbitrary {
 	constraint := constraints.StringDefault()
-	if len(limits) == 0 {
+	if len(limits) != 0 {
 		constraint = limits[0]
 	}
 

--- a/generator/uint.go
+++ b/generator/uint.go
@@ -2,9 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"math"
-	"math/big"
-	"math/rand"
 	"reflect"
 
 	"github.com/steffnova/go-check/arbitrary"
@@ -21,28 +18,14 @@ func Uint64(limits ...constraints.Uint64) Arbitrary {
 	if len(limits) > 0 {
 		constraint = limits[0]
 	}
-	return func(target reflect.Type, r *rand.Rand) (Generator, error) {
+	return func(target reflect.Type, r Random) (Generator, error) {
 		if target.Kind() != reflect.Uint64 {
 			return nil, fmt.Errorf("target arbitrary's kind must be Uint64. Got: %s", target.Kind())
 		}
-		return func(rand *rand.Rand) arbitrary.Type {
-			max := big.NewInt(math.MaxInt64)
-			max = max.Mul(max, big.NewInt(int64(constraint.Max/uint64(math.MaxInt64))))
-			max = max.Add(max, big.NewInt(int64(constraint.Max%uint64(math.MaxInt64))))
-
-			min := big.NewInt(math.MaxInt64)
-			min = min.Mul(min, big.NewInt(int64(constraint.Min/uint64(math.MaxInt64))))
-			min = min.Add(min, big.NewInt(int64(constraint.Min%uint64(math.MaxInt64))))
-
-			diff := big.NewInt(0).Sub(max, min)
-			diff = diff.Add(diff, big.NewInt(1))
-
-			n := diff.Rand(r, diff)
-			n = n.Add(diff, min)
-
+		return func() arbitrary.Type {
 			return arbitrary.Uint64{
 				Constraint: constraint,
-				N:          n.Uint64(),
+				N:          r.Uint64(constraint.Min, constraint.Max),
 			}
 		}, nil
 	}

--- a/property.go
+++ b/property.go
@@ -2,7 +2,6 @@ package check
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 	"strings"
 
@@ -28,10 +27,10 @@ func ErrorForInputs(inputs []reflect.Value) Error {
 
 type run func() error
 
-type property func(*rand.Rand) (run, error)
+type property func(generator.Random) (run, error)
 
 func Property(predicate interface{}, arbGenerators ...generator.Arbitrary) property {
-	return func(r *rand.Rand) (run, error) {
+	return func(r generator.Random) (run, error) {
 		generators := make([]generator.Generator, len(arbGenerators))
 
 		switch val := reflect.ValueOf(predicate); {
@@ -59,7 +58,7 @@ func Property(predicate interface{}, arbGenerators ...generator.Arbitrary) prope
 		return func() error {
 			inputs := make([]reflect.Value, len(generators))
 			for index, generate := range generators {
-				inputs[index] = generate(r).Value()
+				inputs[index] = generate().Value()
 			}
 
 			fmt.Printf("\n%#v\n", inputs[0])

--- a/random.go
+++ b/random.go
@@ -1,0 +1,54 @@
+package check
+
+import (
+	"math"
+	"math/big"
+	"math/rand"
+
+	"github.com/steffnova/go-check/generator"
+)
+
+type rng struct {
+	Rand *rand.Rand
+}
+
+func (r rng) Int64(minInt64, maxInt64 int64) int64 {
+	max := big.NewInt(maxInt64)
+	min := big.NewInt(minInt64)
+
+	val := big.NewInt(0).Sub(max, min)
+	val = big.NewInt(0).Add(val, big.NewInt(1))
+	val = val.Rand(r.Rand, val)
+	val = val.Add(val, min)
+
+	return val.Int64()
+}
+
+func (r rng) Uint64(minUint64, maxUint64 uint64) uint64 {
+	max := big.NewInt(math.MaxInt64)
+	max = max.Mul(max, big.NewInt(int64(maxUint64/uint64(math.MaxInt64))))
+	max = max.Add(max, big.NewInt(int64(maxUint64%uint64(math.MaxInt64))))
+
+	min := big.NewInt(math.MaxInt64)
+	min = min.Mul(min, big.NewInt(int64(minUint64/uint64(math.MaxInt64))))
+	min = min.Add(min, big.NewInt(int64(minUint64%uint64(math.MaxInt64))))
+
+	diff := big.NewInt(0).Sub(max, min)
+	diff = diff.Add(diff, big.NewInt(1))
+
+	n := diff.Rand(r.Rand, diff)
+	n = n.Add(diff, min)
+
+	return n.Uint64()
+}
+
+func (r rng) Seed(seed int64) {
+	r.Rand.Seed(seed)
+}
+
+func (r rng) Split() generator.Random {
+	newSeed := r.Int64(math.MinInt64, math.MaxInt64)
+	return &rng{
+		Rand: rand.New(rand.NewSource(newSeed)),
+	}
+}


### PR DESCRIPTION
[Problem]

*rand.Rand is not suttable to be passed around as a source of random numbers
(building block for generating random values for other types). Currently
one instance of rand.Rand is shared between all generators. This is causing
some issues as some generators like `generator.Func` needs to alter the
seed based on the hased value of function input parameters, to ensure
function pureness.

The other problem is that some generator.Arbitraries required random number
value from specfied range, like maps and slices, where they are generating
arbitrary lengths. rand.Rand only supports generating these values in range
of [0, n). The current solution was to use numeric generator.Arbitraries and
create their generators inside of Arbitrary, which is a bit unpleasnt approach
and cluncky.

[Solution]

Introduce new Random type:

```go
type Random interface {
    // The first 2 methods are used for generating random numeric value
    // for specified range (int64 & uint64).
    Int64(min, max int64) int64
    Uint64(min, max uint64) uint64

    // Split provides method for generating new Random instance that
    // arbitrary can manipulate without affecting other Randoms
    Split() Random

    // Seed allows for changing the seed of Random
    Seed(seed int64)
}
```

List of other changes:
  - Any composed Arbitrary will pass a Random.Split() value to it's composite
  Arbitraries.
  - generato.Int64 and generator.Uint64 have been reworked to consume new Random interface
  to generate random numeric values
  - generator.Slice and generator.Map have been reworked to use Random
  instead of generator.Int() for generating random length for these containers

Closes #9