### PR TITLE
[/feature/issues/5] Add Generator for complex numbers

### DIFF
--- a/constraints/complex.go
+++ b/constraints/complex.go
@@ -1,0 +1,25 @@
+package constraints
+
+type Complex64 struct {
+	Real      Float32
+	Imaginary Float32
+}
+
+func Complex64Default() Complex64 {
+	return Complex64{
+		Real:      Float32Default(),
+		Imaginary: Float32Default(),
+	}
+}
+
+type Complex128 struct {
+	Real      Float64
+	Imaginary Float64
+}
+
+func Complex128Default() Complex128 {
+	return Complex128{
+		Real:      Float64Default(),
+		Imaginary: Float64Default(),
+	}
+}

--- a/generator/any.go
+++ b/generator/any.go
@@ -17,6 +17,14 @@ func Any() Arbitrary {
 			generator = Array(Any())
 		case reflect.Bool:
 			generator = Bool()
+		case reflect.Complex64:
+			generator = Complex64()
+		case reflect.Complex128:
+			generator = Complex128()
+		case reflect.Float32:
+			generator = Float32()
+		case reflect.Float64:
+			generator = Float64()
 		case reflect.Int:
 			generator = Int()
 		case reflect.Int8:

--- a/generator/arbitrary.go
+++ b/generator/arbitrary.go
@@ -35,7 +35,7 @@ func (arb Arbitrary) Map(mapper interface{}) Arbitrary {
 		case err != nil:
 			return nil, fmt.Errorf("failed to create base generator. %s", err)
 		case val.Type().Out(0).Kind() != target.Kind():
-			return nil, fmt.Errorf("mappers output parameter's kind must match target's kind")
+			return nil, fmt.Errorf("mappers output parameter's kind must match target's kind. Got: %s", target.Kind())
 		default:
 			return func() arbitrary.Type {
 				arbType := generateMappedValue()

--- a/generator/array.go
+++ b/generator/array.go
@@ -23,12 +23,56 @@ func Array(element Arbitrary) Arbitrary {
 
 		return func() arbitrary.Type {
 			val := reflect.New(reflect.ArrayOf(target.Len(), target.Elem())).Elem()
-			for index := 0; index < target.Len(); index++ {
-				val.Index(index).Set(generate().Value())
+			elements := make([]arbitrary.Type, target.Len())
+			// for index := 0; index < target.Len(); index++ {
+			for index := range elements {
+				elements[index] = generate()
+				val.Index(index).Set(elements[index].Value())
 			}
 
 			return arbitrary.Array{
-				Val: val,
+				Elements: elements,
+				Val:      val,
+			}
+		}, nil
+	}
+}
+
+// ArrayFrom returns Arbitrary that creates array Generator. Unlike Array, ArrayFrom
+// accepts the variadic number of Arbitraries through arbs parameter, where each arb is
+// used to generate one element of the array. This behavior allows imposing different
+// constraints for each element in the array. Array's size is defined by Generator's target.
+// Error is returned If target's kind is reflect.Array, len(arbs) doesn't match the size
+// target array or Generator creation for any of the array's elements fails.
+func ArrayFrom(arbs ...Arbitrary) Arbitrary {
+	return func(target reflect.Type, r Random) (Generator, error) {
+		if target.Kind() != reflect.Array {
+			return nil, fmt.Errorf("target arbitrary's kind must be Array. Got: %s", target.Kind())
+		}
+		if target.Len() != len(arbs) {
+			return nil, fmt.Errorf("invalid number of arbs. Expected: %d", target.Len())
+		}
+
+		generators := make([]Generator, target.Len())
+		for index := range generators {
+			generator, err := arbs[index](target.Elem(), r.Split())
+			if err != nil {
+				return nil, fmt.Errorf("failed to create element's generator. %s", err)
+			}
+			generators[index] = generator
+		}
+
+		return func() arbitrary.Type {
+			val := reflect.New(reflect.ArrayOf(target.Len(), target.Elem())).Elem()
+			elements := make([]arbitrary.Type, target.Len())
+			for index := 0; index < target.Len(); index++ {
+				elements[index] = generators[index]()
+				val.Index(index).Set(elements[index].Value())
+			}
+
+			return arbitrary.Array{
+				Elements: elements,
+				Val:      val,
 			}
 		}, nil
 	}

--- a/generator/complex.go
+++ b/generator/complex.go
@@ -1,0 +1,53 @@
+package generator
+
+import (
+	"github.com/steffnova/go-check/constraints"
+)
+
+// Complex128 is Arbitrary that creates complex128 Generator. Range in which complex128 value is
+// generated is defined by limits parameter that specifies range in which both real and imaginary
+// part of complex number are generated. Range is a float64 range with minimal and maximum value
+// (min and max are included in range). If no constraints are provided default range for float64
+// is used [-math.MaxFloat64, math.MaxFloat64] for both parts. Even though limits is a variadic
+// argument only the first value is used for defining constraints. Error is returned if target's
+// reflect.Kind is not Complex128 or constraints are out of range (-Inf, +Inf, Nan).
+func Complex128(limits ...constraints.Complex128) Arbitrary {
+	constraint := constraints.Complex128Default()
+	if len(limits) != 0 {
+		constraint = limits[0]
+	}
+
+	return ArrayFrom(
+		Float64(constraint.Real),
+		Float64(constraint.Imaginary),
+	).Map(func(parts [2]float64) complex128 {
+		return complex128(complex(parts[0], parts[1]))
+	})
+}
+
+// Complex64 is Arbitrary that creates complex64 Generator. Range in which complex64 value is
+// generated is defined by limits parameter that specifies range in which both real and imaginary
+// part of complex number are generated. Range is a float32 range with minimal and maximum value
+// (min and max are included in range). If no constraints are provided default range for float64
+// is used [-math.MaxFloat32, math.MaxFloat32] for both parts. Even though limits is a variadic
+// argument only the first value is used for defining constraints. Error is returned if target's
+// reflect.Kind is not Complex64 or constraints are out of range (-Inf, +Inf, Nan).
+func Complex64(limits ...constraints.Complex64) Arbitrary {
+	constraint := constraints.Complex64Default()
+	if len(limits) != 0 {
+		constraint = limits[0]
+	}
+
+	return Complex128(constraints.Complex128{
+		Real: constraints.Float64{
+			Min: float64(constraint.Real.Min),
+			Max: float64(constraint.Real.Max),
+		},
+		Imaginary: constraints.Float64{
+			Min: float64(constraint.Imaginary.Min),
+			Max: float64(constraint.Imaginary.Max),
+		},
+	}).Map(func(n complex128) complex64 {
+		return complex64(n)
+	})
+}

--- a/generator/float.go
+++ b/generator/float.go
@@ -23,7 +23,7 @@ func Float64(limits ...constraints.Float64) Arbitrary {
 
 	return func(target reflect.Type, r Random) (Generator, error) {
 		if target.Kind() != reflect.Float64 {
-			return nil, fmt.Errorf("target arbitrary's kind must be Int64. Got: %s", target.Kind())
+			return nil, fmt.Errorf("target arbitrary's kind must be Float64. Got: %s", target.Kind())
 		}
 		if constraint.Min < -math.MaxFloat64 {
 			return nil, fmt.Errorf("lower range value can't be lower then %f", -math.MaxFloat64)

--- a/random.go
+++ b/random.go
@@ -43,7 +43,7 @@ func (r rng) Uint64(minUint64, maxUint64 uint64) uint64 {
 }
 
 func (r rng) Float64(minFloat64, maxFloat64 float64) float64 {
-	deviation := minFloat64/2 - maxFloat64/2
+	deviation := maxFloat64/2 - minFloat64/2
 	mean := deviation + minFloat64
 
 	for {


### PR DESCRIPTION
[Problem]
Support for generating random complex64 and complex128 numbers

[Solution]
Add new Array generator that allows defining different constraints for
every element of the array. This way float tupple [float64, float64] can
be mapped to Complex128 number. As with other numberics Complex64 can be
derived from Complex128.

Close #4
Close #5