### PR TITLE
[feature/issues/8] Hash input of generated function to create seed for Random

### DIFF
--- a/arbitrary/encode-to-string.go
+++ b/arbitrary/encode-to-string.go
@@ -1,0 +1,107 @@
+package arbitrary
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+type stringEncoder func(val reflect.Value) string
+
+func (s stringEncoder) Nil() stringEncoder {
+	return func(val reflect.Value) string {
+		switch val.Kind() {
+		case reflect.Slice, reflect.Chan, reflect.Map, reflect.Ptr:
+			if val.IsZero() {
+				return "(nil)"
+			}
+			fallthrough
+		default:
+			return s(val)
+		}
+	}
+}
+
+func (s stringEncoder) Type() stringEncoder {
+	return func(val reflect.Value) string {
+		return fmt.Sprintf("<%s> %s", val.Type().String(), s(val))
+	}
+}
+
+func (s stringEncoder) ArrayOrSlice() stringEncoder {
+	return func(val reflect.Value) string {
+		switch val.Kind() {
+		case reflect.Slice, reflect.Array:
+			data := make([]string, val.Len())
+			for index := 0; index < val.Len(); index++ {
+				data[index] = s(val.Index(index))
+			}
+			return fmt.Sprintf("[%s]", strings.Join(data, ", "))
+		default:
+			return s(val)
+		}
+	}
+}
+
+func (s stringEncoder) Map() stringEncoder {
+	return func(val reflect.Value) string {
+		switch val.Kind() {
+		case reflect.Map:
+			data := make([]string, val.Len())
+
+			// In order to present Map data in predictable way every time
+			// it's keys are sorted by their encoded string value
+			keys := val.MapKeys()
+			sort.SliceStable(keys, func(i1, i2 int) bool {
+				return s(keys[i1]) > s(keys[i2])
+			})
+			for index, key := range keys {
+				data[index] = fmt.Sprintf("%s: %s", s(key), s(val.MapIndex(key)))
+			}
+			return fmt.Sprintf("{%s}", strings.Join(data, ", "))
+		default:
+			return s(val)
+		}
+	}
+}
+
+func (s stringEncoder) Struct() stringEncoder {
+	return func(val reflect.Value) string {
+		switch val.Kind() {
+		case reflect.Struct:
+			data := make([]string, val.NumField())
+			for index := 0; index < val.NumField(); index++ {
+				data[index] = fmt.Sprintf("\"%s\": %s", val.Type().Field(index).Name, s.Type()(val.Field(index)))
+			}
+			return fmt.Sprintf("{%s}", strings.Join(data, ", "))
+		default:
+			return s(val)
+		}
+	}
+}
+
+func encodeToString() stringEncoder {
+	return func(val reflect.Value) string {
+		s := encodeToString()
+		switch val.Kind() {
+		case reflect.Slice, reflect.Array:
+			return s.Nil().ArrayOrSlice()(val)
+		case reflect.Map:
+			return s.Nil().Map()(val)
+		case reflect.Struct:
+			return s.Struct()(val)
+		case reflect.Ptr:
+			return s.Nil().Type()(val.Elem())
+		case reflect.Func, reflect.Chan:
+			return fmt.Sprintf("(%#x)", val.Pointer())
+		default:
+			return fmt.Sprintf("%v", val.Interface())
+		}
+	}
+}
+
+// EncodeToString encodes val to it's string representation.
+func EncodeToString(val reflect.Value) string {
+	return encodeToString().Nil().Type()(val)
+}

--- a/arbitrary/hash.go
+++ b/arbitrary/hash.go
@@ -1,0 +1,17 @@
+package arbitrary
+
+import (
+	"hash/fnv"
+	"reflect"
+)
+
+func HashToInt64(vals ...reflect.Value) int64 {
+	data := ""
+	for _, val := range vals {
+		data += EncodeToString(val)
+	}
+
+	h64 := fnv.New64()
+	h64.Write([]byte(data))
+	return int64(h64.Sum64())
+}

--- a/arbitrary/struct.go
+++ b/arbitrary/struct.go
@@ -1,6 +1,9 @@
 package arbitrary
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+)
 
 type StructField struct {
 	Name string
@@ -18,6 +21,10 @@ func (s Struct) Shrink() []Type {
 func (s Struct) Value() reflect.Value {
 	fields := make([]reflect.StructField, len(s.Fields), len(s.Fields))
 	for index, field := range s.Fields {
+		fmt.Println(field.Type.Value().Type())
+		if field.Type.Value().Type().PkgPath() != "" {
+			continue
+		}
 		fields[index] = reflect.StructField{
 			Name: field.Name,
 			Type: field.Type.Value().Type(),

--- a/constraints/int.go
+++ b/constraints/int.go
@@ -79,7 +79,7 @@ type Int64 struct {
 
 func Int64Default() Int64 {
 	return Int64{
-		Min: math.MinInt16,
-		Max: math.MaxInt16,
+		Min: math.MinInt64,
+		Max: math.MaxInt64,
 	}
 }

--- a/constraints/uint.go
+++ b/constraints/uint.go
@@ -67,6 +67,6 @@ type Uint64 struct {
 func Uint64Default() Uint64 {
 	return Uint64{
 		Min: 0,
-		Max: math.MaxUint16,
+		Max: math.MaxUint64,
 	}
 }

--- a/generator/any.go
+++ b/generator/any.go
@@ -67,6 +67,6 @@ func Any() Arbitrary {
 			return nil, fmt.Errorf("no support for generating values for kind: %s", target.Kind())
 		}
 
-		return generator(target, r.Split())
+		return generator(target, r)
 	}
 }

--- a/generator/arbitrary.go
+++ b/generator/arbitrary.go
@@ -30,7 +30,7 @@ func (arb Arbitrary) Map(mapper interface{}) Arbitrary {
 			return nil, fmt.Errorf("mapper must have 1 input value")
 		}
 
-		generateMappedValue, err := arb(val.Type().In(0), r.Split())
+		generateMappedValue, err := arb(val.Type().In(0), r)
 		switch {
 		case err != nil:
 			return nil, fmt.Errorf("failed to create base generator. %s", err)
@@ -59,7 +59,7 @@ func (arb Arbitrary) Map(mapper interface{}) Arbitrary {
 // try to generate target's values unitl predicate is satisfied.
 func (arb Arbitrary) Filter(predicate interface{}) Arbitrary {
 	return func(target reflect.Type, r Random) (Generator, error) {
-		generate, err := arb(target, r.Split())
+		generate, err := arb(target, r)
 		switch val := reflect.ValueOf(predicate); {
 		case err != nil:
 			return nil, fmt.Errorf("failed to create base generator. %s", err)

--- a/generator/array.go
+++ b/generator/array.go
@@ -16,7 +16,7 @@ func Array(element Arbitrary) Arbitrary {
 		if target.Kind() != reflect.Array {
 			return nil, fmt.Errorf("target arbitrary's kind must be Array. Got: %s", target.Kind())
 		}
-		generate, err := element(target.Elem(), r.Split())
+		generate, err := element(target.Elem(), r)
 		if err != nil {
 			return nil, fmt.Errorf("failed to crete generator. %s", err)
 		}
@@ -55,7 +55,7 @@ func ArrayFrom(arbs ...Arbitrary) Arbitrary {
 
 		generators := make([]Generator, target.Len())
 		for index := range generators {
-			generator, err := arbs[index](target.Elem(), r.Split())
+			generator, err := arbs[index](target.Elem(), r)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create element's generator. %s", err)
 			}

--- a/generator/map.go
+++ b/generator/map.go
@@ -22,12 +22,12 @@ func Map(key, value Arbitrary, limits ...constraints.Length) Arbitrary {
 			constraint = limits[0]
 		}
 
-		generateKey, err := key(target.Key(), r.Split())
+		generateKey, err := key(target.Key(), r)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create map's Key generator. %s", err)
 		}
 
-		generateValue, err := value(target.Elem(), r.Split())
+		generateValue, err := value(target.Elem(), r)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create map's Value generator. %s", err)
 		}

--- a/generator/one-of.go
+++ b/generator/one-of.go
@@ -13,7 +13,7 @@ func OneOf(first Arbitrary, other ...Arbitrary) Arbitrary {
 		index := int(r.Int64(0, int64(len(arbitraries)-1)))
 		arb := arbitraries[index]
 
-		gen, err := arb(target, r.Split())
+		gen, err := arb(target, r)
 		if err != nil {
 			return nil, err
 		}

--- a/generator/ptr.go
+++ b/generator/ptr.go
@@ -42,7 +42,7 @@ func PtrValid(arb Arbitrary) Arbitrary {
 			return nil, fmt.Errorf("target's kind must be Ptr. Got: %s", target.Kind())
 		}
 
-		generateValue, err := arb(target.Elem(), r.Split())
+		generateValue, err := arb(target.Elem(), r)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create base generator. %s", err)
 		}

--- a/generator/slice.go
+++ b/generator/slice.go
@@ -24,7 +24,7 @@ func Slice(element Arbitrary, limits ...constraints.Length) Arbitrary {
 			return nil, fmt.Errorf("targets kind must be Slice. Got: %s", target.Kind())
 		}
 
-		generateElement, err := element(target.Elem(), r.Split())
+		generateElement, err := element(target.Elem(), r)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create generator for slice elements: %s", err)
 		}

--- a/generator/struct.go
+++ b/generator/struct.go
@@ -28,7 +28,7 @@ func Struct(fieldArbitraries ...map[string]Arbitrary) Arbitrary {
 			if !exists {
 				generator = Any()
 			}
-			generate, err := generator(field.Type, r.Split())
+			generate, err := generator(field.Type, r)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create generator for field: %s. %s", field.Name, err)
 			}


### PR DESCRIPTION
[Problem]

generator.Func() should create pure functions, for same input a same output
should be generated. 2 generated functions with same signatures should
be different from one another, such that for same input they generate different
output.

[Solution]

Function input is encoded to it's string representation and than hashed
using fnv.Hash64. Input is mapped to int64, so it can be used as a seed
for Random of function output generators.

Added a way to create string representation for all Go's basic types except
interfaces{}. This is done in arbitrary package for now, with function
EncodeToString(). Idea is for it to be used by check package as well.

There was an issue with previous implementation of passing Random between
Generators. All Generators were splitting from parent Random, but this
proved to be a bad strategy because these generators couldn't be used
for generating function output predictably. As soon as the Random is split
seed altered in generated function body didn't affect the generators for output,
because they were using completely different Random. Random is now split only
when it's seed needs to be manipulated for predictable output.

Close #8