### PR TITLE
[bugfix/issues/16] Generation of composite structures fails

### DIFF
--- a/arbitrary/struct.go
+++ b/arbitrary/struct.go
@@ -1,7 +1,6 @@
 package arbitrary
 
 import (
-	"fmt"
 	"reflect"
 )
 
@@ -11,7 +10,8 @@ type StructField struct {
 }
 
 type Struct struct {
-	Fields []StructField
+	Fields map[string]Type
+	Type   reflect.Type
 }
 
 func (s Struct) Shrink() []Type {
@@ -19,21 +19,9 @@ func (s Struct) Shrink() []Type {
 }
 
 func (s Struct) Value() reflect.Value {
-	fields := make([]reflect.StructField, len(s.Fields), len(s.Fields))
-	for index, field := range s.Fields {
-		fmt.Println(field.Type.Value().Type())
-		if field.Type.Value().Type().PkgPath() != "" {
-			continue
-		}
-		fields[index] = reflect.StructField{
-			Name: field.Name,
-			Type: field.Type.Value().Type(),
-		}
-	}
-
-	v := reflect.New(reflect.StructOf(fields)).Elem()
-	for index, field := range s.Fields {
-		v.Field(index).Set(field.Type.Value())
+	v := reflect.New(s.Type).Elem()
+	for name, t := range s.Fields {
+		v.FieldByName(name).Set(t.Value())
 	}
 	return v
 }

--- a/generator/struct.go
+++ b/generator/struct.go
@@ -36,15 +36,14 @@ func Struct(fieldArbitraries ...map[string]Arbitrary) Arbitrary {
 		}
 
 		return func() arbitrary.Type {
-			fields := make([]arbitrary.StructField, target.NumField())
-			for index := range fields {
-				fields[index] = arbitrary.StructField{
-					Name: target.Field(index).Name,
-					Type: generators[index](),
-				}
+			fields := make(map[string]arbitrary.Type, target.NumField())
+			for index := 0; index < target.NumField(); index++ {
+				field := target.Field(index)
+				fields[field.Name] = generators[index]()
 			}
 			return arbitrary.Struct{
 				Fields: fields,
+				Type:   target,
 			}
 		}, nil
 	}


### PR DESCRIPTION
[Problem]

```go
type C1 struct {}
type C2 struct {}

type C struct {
    C1
    C2
}
```

If there is a type as shown in the example above, assignment of generated
value to type C will fail.

[Solution]

The issue is with how creation of Struct is done by reflect package. In
the current itteration target type is constructed from struct fields,
which in this case is:

```go
struct { C1: struct{}, C2: struct{}}
```

Embedded types have a field in a parent structure that nmatches the name
of a type. But it seems that creating a structure from these fields is not
the same as embedding types into structure itself. Solution to this problem
is to use target as type reference during the call to reflect.New instead of using
struct fields to create structure's type by using reflect.StructOf.

As a side effect this change removes alot of code as well.

Close #16