### PR TITLE
[feature/issues/20] Shrinker interface

### DIFF
--- a/generator/chan.go
+++ b/generator/chan.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/steffnova/go-check/arbitrary"
 	"github.com/steffnova/go-check/constraints"
+	"github.com/steffnova/go-check/shrinker"
 )
 
 // Chan returns Arbitrary that creates chan Generator. Range in which channel's buffer
@@ -22,13 +22,12 @@ func Chan(limits ...constraints.Length) Arbitrary {
 		if target.Kind() != reflect.Chan {
 			return nil, fmt.Errorf("target arbitrary's kind must be Chan. Got: %s", target.Kind())
 		}
-		return func() arbitrary.Type {
-			return arbitrary.Chan{
-				C: reflect.MakeChan(
-					reflect.ChanOf(reflect.BothDir, target.Elem()),
-					int(r.Int64(int64(constraint.Min), int64(constraint.Max))),
-				),
-			}
+		return func() (reflect.Value, shrinker.Shrinker) {
+			val := reflect.MakeChan(
+				reflect.ChanOf(reflect.BothDir, target.Elem()),
+				int(r.Int64(int64(constraint.Min), int64(constraint.Max))),
+			)
+			return val, nil
 		}, nil
 	}
 }

--- a/generator/constant.go
+++ b/generator/constant.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/steffnova/go-check/arbitrary"
+	"github.com/steffnova/go-check/shrinker"
 )
 
 // Constant is arbitrary that creates generator of constant value. Value returned
@@ -22,10 +22,8 @@ func Constant(constant interface{}) Arbitrary {
 		case target.Kind() == reflect.TypeOf(constant).Kind():
 			fallthrough
 		case target.Kind() == reflect.Interface && reflect.TypeOf(constant).Implements(target):
-			return func() arbitrary.Type {
-				return arbitrary.Constant{
-					C: reflect.ValueOf(constant),
-				}
+			return func() (reflect.Value, shrinker.Shrinker) {
+				return reflect.ValueOf(constant), nil
 			}, nil
 		default:
 			return nil, fmt.Errorf("constant %s doesn't match the target's type: %s", reflect.TypeOf(constant).Kind().String(), target.String())

--- a/generator/float.go
+++ b/generator/float.go
@@ -5,8 +5,8 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/steffnova/go-check/arbitrary"
 	"github.com/steffnova/go-check/constraints"
+	"github.com/steffnova/go-check/shrinker"
 )
 
 // Float64 is Arbitrary that creates float64 Generator. Range in which float64 value is generated
@@ -35,11 +35,9 @@ func Float64(limits ...constraints.Float64) Arbitrary {
 			return nil, fmt.Errorf("lower range value can't be greater then upper range value")
 		}
 
-		return func() arbitrary.Type {
-			return arbitrary.Float64{
-				Constraint: constraint,
-				N:          r.Float64(constraint.Min, constraint.Max),
-			}
+		return func() (reflect.Value, shrinker.Shrinker) {
+			n := r.Float64(constraint.Min, constraint.Max)
+			return reflect.ValueOf(n), nil
 		}, nil
 	}
 }

--- a/generator/func.go
+++ b/generator/func.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/steffnova/go-check/arbitrary"
+	"github.com/steffnova/go-check/shrinker"
 )
 
 // Func is Arbitrary that creates function Generator. Generator returns pure
@@ -35,24 +36,25 @@ func Func(outputs ...Arbitrary) Arbitrary {
 			randoms[index] = random
 		}
 		randomInt64 := r.Int64(math.MinInt64, math.MaxInt64)
-		return func() arbitrary.Type {
-			return arbitrary.Func{
-				Fn: reflect.MakeFunc(target, func(inputs []reflect.Value) []reflect.Value {
-					// In order to create 2 different pure functions that have the
-					// same signature but generate different ouput, random value is
-					// added to the hashed input parameters. This ensure that each
-					// function has differently seeded Random.
-					seed := int64(arbitrary.HashToInt64(inputs...)) + randomInt64
+		return func() (reflect.Value, shrinker.Shrinker) {
+			fn := reflect.MakeFunc(target, func(inputs []reflect.Value) []reflect.Value {
+				// In order to create 2 different pure functions that have the
+				// same signature but generate different ouput, random value is
+				// added to the hashed input parameters. This ensure that each
+				// function has differently seeded Random.
+				seed := int64(arbitrary.HashToInt64(inputs...)) + randomInt64
 
-					outputs := make([]reflect.Value, target.NumOut())
-					for index, generate := range generators {
-						randoms[index].Seed(seed)
-						outputs[index] = generate().Value()
-					}
+				outputs := make([]reflect.Value, target.NumOut())
+				for index, generate := range generators {
+					randoms[index].Seed(seed)
+					outputs[index], _ = generate()
+				}
 
-					return outputs
-				}),
-			}
+				return outputs
+			})
+
+			return fn, nil
+
 		}, nil
 	}
 }

--- a/generator/int.go
+++ b/generator/int.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/steffnova/go-check/arbitrary"
 	"github.com/steffnova/go-check/constraints"
+	"github.com/steffnova/go-check/shrinker"
 )
 
 // Int64 is Arbitrary that creates int64 Generator. Range in which int64 value is generated
@@ -23,11 +23,9 @@ func Int64(limits ...constraints.Int64) Arbitrary {
 		if target.Kind() != reflect.Int64 {
 			return nil, fmt.Errorf("target arbitrary's kind must be Int64. Got: %s", target.Kind())
 		}
-		return func() arbitrary.Type {
-			return arbitrary.Int64{
-				Constraint: constraint,
-				N:          r.Int64(constraint.Min, constraint.Max),
-			}
+		return func() (reflect.Value, shrinker.Shrinker) {
+			n := r.Int64(constraint.Min, constraint.Max)
+			return reflect.ValueOf(n), nil
 		}, nil
 	}
 }

--- a/generator/map.go
+++ b/generator/map.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/steffnova/go-check/arbitrary"
 	"github.com/steffnova/go-check/constraints"
+	"github.com/steffnova/go-check/shrinker"
 )
 
 // Map is arbitrary that creates map Generator. key and value parameters
@@ -32,22 +32,17 @@ func Map(key, value Arbitrary, limits ...constraints.Length) Arbitrary {
 			return nil, fmt.Errorf("failed to create map's Value generator. %s", err)
 		}
 
-		return func() arbitrary.Type {
+		return func() (reflect.Value, shrinker.Shrinker) {
 			size := r.Int64(int64(constraint.Min), int64(constraint.Max))
-			pairs := make([]arbitrary.KeyValue, size)
-			for index := range pairs {
-				pairs[index] = arbitrary.KeyValue{
-					Key:   generateKey(),
-					Value: generateValue(),
-				}
+
+			val := reflect.MakeMapWithSize(target, int(size))
+			for i := 0; i < int(size); i++ {
+				key, _ := generateKey()
+				value, _ := generateValue()
+				val.SetMapIndex(key, value)
 			}
 
-			return arbitrary.Map{
-				Constraint: constraint,
-				Key:        target.Key(),
-				Val:        target.Elem(),
-				Pairs:      pairs,
-			}
+			return val, nil
 		}, nil
 	}
 }

--- a/generator/nil.go
+++ b/generator/nil.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/steffnova/go-check/arbitrary"
+	"github.com/steffnova/go-check/shrinker"
 )
 
 // Nil is Arbitrary that creates nil Generator. Generates nil value for
@@ -14,10 +14,8 @@ func Nil() Arbitrary {
 	return func(target reflect.Type, _ Random) (Generator, error) {
 		switch target.Kind() {
 		case reflect.Chan, reflect.Slice, reflect.Map, reflect.Func, reflect.Interface, reflect.Ptr:
-			return func() arbitrary.Type {
-				return arbitrary.Constant{
-					C: reflect.Zero(target),
-				}
+			return func() (reflect.Value, shrinker.Shrinker) {
+				return reflect.Zero(target), nil
 			}, nil
 		default:
 			return nil, fmt.Errorf("nil is not a valid value for target: %s", target.String())

--- a/generator/ptr.go
+++ b/generator/ptr.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/steffnova/go-check/arbitrary"
+	"github.com/steffnova/go-check/shrinker"
 )
 
 // Ptr is Arbitrary that creates pointer Generator. Generator will return
@@ -29,11 +29,11 @@ func PtrValid(arb Arbitrary) Arbitrary {
 			return nil, fmt.Errorf("failed to create base generator. %s", err)
 		}
 
-		return func() arbitrary.Type {
-			return arbitrary.Ptr{
-				Type:        target,
-				ElementType: generateValue(),
-			}
+		return func() (reflect.Value, shrinker.Shrinker) {
+			val, _ := generateValue()
+			ptr := reflect.New(target).Elem()
+			ptr.Elem().Set(val)
+			return ptr, nil
 		}, nil
 	}
 }

--- a/generator/uint.go
+++ b/generator/uint.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/steffnova/go-check/arbitrary"
 	"github.com/steffnova/go-check/constraints"
+	"github.com/steffnova/go-check/shrinker"
 )
 
 // Uint64 is Arbitrary that creates uint64 Generator. Range in which uint64 value is generated
@@ -22,11 +22,9 @@ func Uint64(limits ...constraints.Uint64) Arbitrary {
 		if target.Kind() != reflect.Uint64 {
 			return nil, fmt.Errorf("target arbitrary's kind must be Uint64. Got: %s", target.Kind())
 		}
-		return func() arbitrary.Type {
-			return arbitrary.Uint64{
-				Constraint: constraint,
-				N:          r.Uint64(constraint.Min, constraint.Max),
-			}
+		return func() (reflect.Value, shrinker.Shrinker) {
+			n := r.Uint64(constraint.Min, constraint.Max)
+			return reflect.ValueOf(n), nil
 		}, nil
 	}
 }

--- a/property.go
+++ b/property.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/steffnova/go-check/generator"
+	"github.com/steffnova/go-check/shrinker"
 )
 
 type Error func() string
@@ -48,17 +49,16 @@ func Property(predicate interface{}, arbGenerators ...generator.Arbitrary) prope
 				if err != nil {
 					return nil, fmt.Errorf("failed to create type generator at index [%d]. %s", index, err)
 				}
-				// if !generator.Type.ConvertibleTo(val.Type().In(index)) {
-				// 	return nil, fmt.Errorf("generator's arbitrary type (%s) can't be assigned to predicate's input type (%s)", generator.Type, val.Type().In(index))
-				// }
 				generators[index] = generate
 			}
 		}
 
 		return func() error {
 			inputs := make([]reflect.Value, len(generators))
+			shrinkers := make([]shrinker.Shrinker, len(generators))
+
 			for index, generate := range generators {
-				inputs[index] = generate().Value()
+				inputs[index], shrinkers[index] = generate()
 			}
 
 			outputs := reflect.ValueOf(predicate).Call(inputs)

--- a/shrinker/shrinker.go
+++ b/shrinker/shrinker.go
@@ -1,0 +1,25 @@
+package shrinker
+
+import "reflect"
+
+// Shrinker returns shrinked value and next shrinker. Returned values
+// are usually affected by propertyFailed parameter. It helps shrinker
+// to decide how to properly shrink the value. If returned Shrinker
+// is nil, it indicates that value can no longer be shrinked
+type Shrinker func(propertyFailed bool) (reflect.Value, Shrinker)
+
+// Map maps the shrinked value to a new one using the mapper. Mapper
+// must be a function with one input and one output parameter. Input
+// parameter must match shrinked type, otherwise panic occurs.
+func (shrinker Shrinker) Map(mapper interface{}) Shrinker {
+	return func(propertyFailed bool) (reflect.Value, Shrinker) {
+		shrink, shrinker := shrinker(propertyFailed)
+		shrink = reflect.ValueOf(mapper).Call([]reflect.Value{shrink})[0]
+
+		if shrinker == nil {
+			return shrink, nil
+		}
+
+		return shrink, shrinker.Map(mapper)
+	}
+}


### PR DESCRIPTION
[Problem]

Property based testing framework needs to have a shrinker feature as without
it it is just a fuzzing generator.

[Solution]

Define common interface for shrinkers that will be used for all supported
generator types. Shrinker should be returned from generators, along with
a generated value.

Property should collect all shrinkers for generated values and use them
when property fails, to shrink generated values to smallest failing value.

Shinker is aware of property failing through propertyFailed parameter. This
information helps shrinker to shrink value properly on property failure and
success so it can converge to smallest failing value. Shrinker is a recursive
function where each shrinker returns a shrinked value and Shrinker to shrink
further. When returned shrinker is nil, value can no longer be shrinked.

All Generators now return generated value in form of reflect.Value and Shrinker.

Close #20