### PR TITLE
[feature/issues/21] Shrinker for Int

### DIFF
--- a/check.go
+++ b/check.go
@@ -35,7 +35,7 @@ func Check(t *testing.T, property property, config ...Config) {
 
 	for i := int64(0); i < configuration.Iterations; i++ {
 		if err := run(); err != nil {
-			t.Fatalf("\nCheck failed with seed: %d. \n%s", configuration.Seed, err)
+			t.Fatalf("\nCheck failed after %d tests with seed: %d. \n%s", i+1, configuration.Seed, err)
 		}
 	}
 }

--- a/generator/int.go
+++ b/generator/int.go
@@ -25,7 +25,7 @@ func Int64(limits ...constraints.Int64) Arbitrary {
 		}
 		return func() (reflect.Value, shrinker.Shrinker) {
 			n := r.Int64(constraint.Min, constraint.Max)
-			return reflect.ValueOf(n), nil
+			return reflect.ValueOf(n), shrinker.Int64(n, constraint)
 		}, nil
 	}
 }

--- a/shrinker/int.go
+++ b/shrinker/int.go
@@ -1,0 +1,43 @@
+package shrinker
+
+import (
+	"reflect"
+
+	"github.com/steffnova/go-check/constraints"
+)
+
+// Int64 is a shrinker for int64. X is the shrinking target and limits are
+// constraints in which x will be shrunk. If x >= 0 it will be shrunk towards
+// limits.Min or 0 whichever is higher. If x < 0 it will be shrunk towards 0
+// or limits.Max, whichever is higher.
+func Int64(n int64, limits constraints.Int64) Shrinker {
+	switch {
+	case n >= 0 && limits.Min < 0:
+		limits.Min = 0
+	case n < 0 && limits.Max > 0:
+		limits.Max = 0
+	}
+
+	return func(propertyFailed bool) (reflect.Value, Shrinker) {
+		switch {
+		case limits.Max == limits.Min:
+			return reflect.ValueOf(n), nil
+		case n >= 0:
+			if propertyFailed {
+				limits.Max = n
+			} else {
+				limits.Min = n + 1
+			}
+			shrinked := limits.Min + (limits.Max-limits.Min)/2
+			return reflect.ValueOf(shrinked), Int64(shrinked, limits)
+		default:
+			if propertyFailed {
+				limits.Min = n
+			} else {
+				limits.Max = n - 1
+			}
+			shrinked := limits.Max - (limits.Max-limits.Min)/2
+			return reflect.ValueOf(shrinked), Int64(shrinked, limits)
+		}
+	}
+}


### PR DESCRIPTION
[Problem]

On a test failure where input is one of the:
```go
int
int8
int16
int32
int64
```

The value of that input should be shrunk to smallest possible value where test still fails.

[Solution]

Add Shrinker for int64. Due to the nature of Int generators, shrinking is inherited from Int64 generator implicitly.
Shrinking strategy is split into two parts: one for positive integers and one for negative integers. Both strategies are shrinking values towards the 0, or towards minimum/maximum in case of positive/negative numbers if minimum/maximum is lower/higher than 0.

NOTE: Property and Check have been updates in order to display total number of shrinks and tests before the failure.

Close #21