### PR TITLE
[bugfix/issues/32] Shrinking of negative int64 fails to shrink around 0

### DIFF
--- a/shrinker/int.go
+++ b/shrinker/int.go
@@ -6,38 +6,63 @@ import (
 	"github.com/steffnova/go-check/constraints"
 )
 
-// Int64 is a shrinker for int64. X is the shrinking target and limits are
-// constraints in which x will be shrunk. If x >= 0 it will be shrunk towards
-// limits.Min or 0 whichever is higher. If x < 0 it will be shrunk towards 0
-// or limits.Max, whichever is higher.
+// Int64 is a shrinker for int64. N is the shrinking target and limits are
+// constraints in which n will be shrunk. If n > 0 it will be shrunk towards
+// limits.Min or 0 whichever is higher. If n < 0 it will be shrunk towards 0
+// or limits.Max, whichever is lower. If n == 0 it will be returned with no
+// shrinker as it is converging point in ranges [math.Int64Min, 0] and [0, math.Int64Max]
 func Int64(n int64, limits constraints.Int64) Shrinker {
 	switch {
-	case n >= 0 && limits.Min < 0:
-		limits.Min = 0
-	case n < 0 && limits.Max > 0:
-		limits.Max = 0
+	case n > 0:
+		return int64Positive(n, limits)
+	case n < 0:
+		return int64Negative(n, limits)
+	default:
+		return func(propertyFailed bool) (reflect.Value, Shrinker) {
+			return reflect.ValueOf(int64(0)), nil
+		}
 	}
 
+}
+
+// int64Positive is a shrinker of positive int64 numbers. All numbers
+// are shrunk towards 0 or limits.Min whichever is higher.
+func int64Positive(n int64, limits constraints.Int64) Shrinker {
+	if limits.Min < 0 {
+		limits.Min = 0
+	}
 	return func(propertyFailed bool) (reflect.Value, Shrinker) {
 		switch {
 		case limits.Max == limits.Min:
 			return reflect.ValueOf(n), nil
-		case n >= 0:
-			if propertyFailed {
-				limits.Max = n
-			} else {
-				limits.Min = n + 1
-			}
-			shrinked := limits.Min + (limits.Max-limits.Min)/2
-			return reflect.ValueOf(shrinked), Int64(shrinked, limits)
+		case propertyFailed:
+			limits.Max = n
 		default:
-			if propertyFailed {
-				limits.Min = n
-			} else {
-				limits.Max = n - 1
-			}
-			shrinked := limits.Max - (limits.Max-limits.Min)/2
-			return reflect.ValueOf(shrinked), Int64(shrinked, limits)
+			limits.Min = n + 1
 		}
+
+		shrinked := limits.Max - ((limits.Max-limits.Min)/2 + (limits.Max-limits.Min)%2)
+		return reflect.ValueOf(shrinked), int64Positive(shrinked, limits)
+	}
+}
+
+// int64Negative is a shrinker of negative int64 numbers. All numbers
+// are shrunk towards 0 or limits.Max whichever is lower.
+func int64Negative(n int64, limits constraints.Int64) Shrinker {
+	if limits.Max > 0 {
+		limits.Max = 0
+	}
+	return func(propertyFailed bool) (reflect.Value, Shrinker) {
+		switch {
+		case limits.Max == limits.Min:
+			return reflect.ValueOf(n), nil
+		case propertyFailed:
+			limits.Min = n
+		default:
+			limits.Max = n - 1
+		}
+
+		shrinked := limits.Max - (limits.Max-limits.Min)/2
+		return reflect.ValueOf(shrinked), int64Negative(shrinked, limits)
 	}
 }


### PR DESCRIPTION
[Problem]
https://github.com/steffnova/go-check/issues/32#issuecomment-899030288

[Solution]
Splitting shrinker in composition of 3 shrinkers:
  - Shrinker for negative numbers
  - Shrinker for positive numbers
  - Shrinker for 0

Shrinking of negative numbers is selected if N (target that needs to be shrunk)
is negative. The value will be shrunk towards 0 or limits.Max whichever is
lower.

Shrinking of positive numbers is selected if N (target that needs to be shrunk)
is positive. The value will be shrunk towards 0 or limits.Min whichever is
higher.

Shrinking of 0 returns 0, without shrinker as it is the converging point
for shrinking of both positive and negative numbers

Close #32