### PR TITLE
[feature/issues/24] Add shrinker for Slice

### DIFF
--- a/generator/slice.go
+++ b/generator/slice.go
@@ -34,13 +34,15 @@ func Slice(element Arbitrary, limits ...constraints.Length) Arbitrary {
 			val := reflect.MakeSlice(target, int(size), int(size))
 
 			shrinkers := make([]shrinker.Shrinker, size)
+			values := make([]reflect.Value, size)
 			for index := range shrinkers {
 				element, shrinker := generator()
 				shrinkers[index] = shrinker
+				values[index] = element
 				val.Index(index).Set(element)
 			}
 
-			return val, nil
+			return val, shrinker.Slice(target, values, shrinkers, constraint)
 		}, nil
 	}
 

--- a/shrinker/slice.go
+++ b/shrinker/slice.go
@@ -1,0 +1,56 @@
+package shrinker
+
+import (
+	"reflect"
+
+	"github.com/steffnova/go-check/constraints"
+)
+
+// Slice is a shrinker for slice. Slice is shrinked by two dimensions: elements and size.
+// Shrinking is first done by elements, where in each shrink itteration all elements are
+// shrunk at the same time. When elements can no longer be srunk, size is being shrunk by
+// removing one element at a time. Convergance speed for shrinker is O(n*m), n is slice
+// size and m is convergance speed of slice elements.
+func Slice(target reflect.Type, original []reflect.Value, elementShrinkers []Shrinker, limits constraints.Length) Shrinker {
+	candidates := []reflect.Value{}
+	candidateIndex := 0
+	shrinker := Shrinker(nil)
+
+	shrinker = func(propertyFailed bool) (reflect.Value, Shrinker) {
+		value := reflect.MakeSlice(target, 0, 0)
+		elementsShrunk := true
+
+		for index, elementShrinker := range elementShrinkers {
+			if elementShrinker == nil {
+				continue
+			}
+			elementsShrunk = false
+			original[index], elementShrinkers[index] = elementShrinker(propertyFailed)
+		}
+
+		switch {
+		case !elementsShrunk:
+			// If elements are not shrunk to smalles possible value, keep shrinking them
+			return reflect.Append(value, original...), shrinker
+		case !propertyFailed:
+			// If element removed from a slice causes the property to succeed, it needs to
+			// be added to a candidates as it is essential element for property failure
+			candidates = append(candidates, original[candidateIndex-1])
+			return reflect.Append(value, append(candidates, original[candidateIndex:]...)...), shrinker
+		case limits.Min == len(original)-(candidateIndex-len(candidates)):
+			// Shrinking should stop if we've reached a slice's minimal length defined by constraint.
+			// The last shrunk value is aggregation of candidates and remaning original elements
+			return reflect.Append(value, append(candidates, original[candidateIndex:]...)...), nil
+		case candidateIndex == len(original):
+			// Shrinking should stop if candidate index has passed through all elements.
+			// Candidates is final shrunk value of original slice
+			return reflect.Append(value, candidates...), nil
+		default:
+			// In all other cases property keeps failing so slice size shrinking continues
+			// TODO: See if size shrinking speed can be increased
+			candidateIndex++
+			return reflect.Append(value, append(candidates, original[candidateIndex:]...)...), shrinker
+		}
+	}
+	return shrinker
+}


### PR DESCRIPTION
[Problem]

Slice needs it's own shrinker that will be able to shrink slice of any
type to smallest possbile property failing value.

[Solution]

Slice should be shrunk by two dimensions: elements and size.
This implementation shrinks elements first than size.

Close #24