### PR TITLE
[feature/issues/25] Add shrinker for Uint

### DIFF
--- a/generator/uint.go
+++ b/generator/uint.go
@@ -24,7 +24,7 @@ func Uint64(limits ...constraints.Uint64) Arbitrary {
 		}
 		return func() (reflect.Value, shrinker.Shrinker) {
 			n := r.Uint64(constraint.Min, constraint.Max)
-			return reflect.ValueOf(n), nil
+			return reflect.ValueOf(n), shrinker.Uint64(n, constraint)
 		}, nil
 	}
 }

--- a/shrinker/uint.go
+++ b/shrinker/uint.go
@@ -1,0 +1,26 @@
+package shrinker
+
+import (
+	"reflect"
+
+	"github.com/steffnova/go-check/constraints"
+)
+
+// Uint64 is a shrinker for uint64. N is the shrinking target and limits are
+// constraints in which n will be shrunk. N will be shrunk towards limits.Min
+// or 0 whichever is higher.
+func Uint64(n uint64, limits constraints.Uint64) Shrinker {
+	return func(propertyFailed bool) (reflect.Value, Shrinker) {
+		switch {
+		case limits.Max == limits.Min:
+			return reflect.ValueOf(n), nil
+		case propertyFailed:
+			limits.Max = n
+		default:
+			limits.Min = n + 1
+		}
+
+		shrinked := limits.Max - ((limits.Max-limits.Min)/2 + (limits.Max-limits.Min)%2)
+		return reflect.ValueOf(shrinked), Uint64(shrinked, limits)
+	}
+}


### PR DESCRIPTION
[Problem]

Uint needs it's own shrinker that will be able to shrink all uint types
to smallest possbile property failing value.

[Solution]

Shrinking uint has the same logic as shrinking positive Integers

Close #25