### PR TITLE
[feature/issues/29] Add shrinker for float

### DIFF
--- a/generator/struct.go
+++ b/generator/struct.go
@@ -45,7 +45,7 @@ func Struct(fieldArbitraries ...map[string]Arbitrary) Arbitrary {
 				val.FieldByName(fieldName).Set(fieldVal)
 				shrinkers[fieldName] = shrinker
 			}
-			return val, nil
+			return val, shrinker.Struct(val, shrinkers)
 		}, nil
 	}
 }

--- a/shrinker/struct.go
+++ b/shrinker/struct.go
@@ -1,0 +1,30 @@
+package shrinker
+
+import (
+	"reflect"
+)
+
+// Struct is a shrinker for Go's struct. Struct shrinking consists of shrinking individual
+// fields one by one. Convergance speed for shrinker is O(n*m), n is number of Struct fields
+// and m is convergance speed of field type.
+func Struct(original reflect.Value, fieldShrinkers map[string]Shrinker) Shrinker {
+	return func(propertyFailed bool) (reflect.Value, Shrinker) {
+		for i := 0; i < original.Type().NumField(); i++ {
+			fieldName := original.Type().Field(i).Name
+
+			shrinker := fieldShrinkers[fieldName]
+			if shrinker == nil {
+				continue
+			}
+
+			val, shrinker := shrinker(propertyFailed)
+
+			original.FieldByName(fieldName).Set(val)
+			fieldShrinkers[fieldName] = shrinker
+
+			return original, Struct(original, fieldShrinkers)
+		}
+
+		return original, nil
+	}
+}


### PR DESCRIPTION
[Problem]

Struct types their own shrinker that will be able to shrink struct fields
to smallest possbile property failing value.

[Solution]

Strategy for shrinking a struct is to shrink each field individually.

Close #29