### PR TITLE
[bugfix/issues/39] Bool shrinks towards true instead of false

### DIFF
--- a/generator/bool.go
+++ b/generator/bool.go
@@ -8,6 +8,6 @@ func Bool() Arbitrary {
 		Min: 0,
 		Max: 1,
 	}).Map(func(n int64) bool {
-		return n == 0
+		return n != 0
 	})
 }


### PR DESCRIPTION
[Problem]

Bool should shrink towards false instead of true

[Solution]

The problem lies with generator as 0 is mapped to `true` and 1 is mapped
to `false`

 Close #39