### PR TITLE
[feature/issues/27] Add shrinker for pointer types

### DIFF
--- a/generator/ptr.go
+++ b/generator/ptr.go
@@ -30,10 +30,10 @@ func PtrValid(arb Arbitrary) Arbitrary {
 		}
 
 		return func() (reflect.Value, shrinker.Shrinker) {
-			val, _ := generateValue()
-			ptr := reflect.New(target).Elem()
+			val, valShrinker := generateValue()
+			ptr := reflect.New(target.Elem())
 			ptr.Elem().Set(val)
-			return ptr, nil
+			return ptr, shrinker.Ptr(ptr, valShrinker)
 		}, nil
 	}
 }

--- a/shrinker/ptr.go
+++ b/shrinker/ptr.go
@@ -1,0 +1,34 @@
+package shrinker
+
+import "reflect"
+
+// Ptr is a shrinker for pointers. ElementShrinker is shrinker for type to which
+// ptr points to. Shrinking process consists of shrinking the value to which pointer
+// points to, and shrinking of pointer to nil.
+func Ptr(ptr reflect.Value, elementShrinker Shrinker) Shrinker {
+	var shrinker Shrinker
+	var lastValidPtr reflect.Value
+
+	shrinker = func(propertyFailed bool) (reflect.Value, Shrinker) {
+		var val reflect.Value
+		if elementShrinker != nil {
+			val, elementShrinker = elementShrinker(propertyFailed)
+			ptr.Elem().Set(val)
+			return ptr, shrinker
+		}
+
+		switch {
+		case !ptr.IsNil():
+			// Shrinking to nil could make a property not fail. The last valid pointer
+			// value needs to be saved in order to revert nil pointer if needed.
+			lastValidPtr, ptr = ptr, reflect.Zero(ptr.Type())
+			return ptr, shrinker
+		case propertyFailed:
+			return ptr, nil
+		default:
+			return lastValidPtr, nil
+		}
+	}
+
+	return shrinker
+}


### PR DESCRIPTION
[Problem]

Pointer types should have their own shrinker.

[Solution]

Strategy for shrinking a pointer is to shrink value it points to first.
Afterwards, pointer is shrunk to nil. This change is reverted if property
doesn't fail for nil pointer.

Close #27