### PR TITLE
[feauture/issues/26] Add map shrinker

### DIFF
--- a/generator/slice.go
+++ b/generator/slice.go
@@ -34,15 +34,13 @@ func Slice(element Arbitrary, limits ...constraints.Length) Arbitrary {
 			val := reflect.MakeSlice(target, int(size), int(size))
 
 			shrinkers := make([]shrinker.Shrinker, size)
-			values := make([]reflect.Value, size)
 			for index := range shrinkers {
 				element, shrinker := generator()
 				shrinkers[index] = shrinker
-				values[index] = element
 				val.Index(index).Set(element)
 			}
 
-			return val, shrinker.Slice(target, values, shrinkers, constraint)
+			return val, shrinker.Slice(val, shrinkers, constraint)
 		}, nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/steffnova/go-check
 
 go 1.14
+
+require github.com/leanovate/gopter v0.2.9 // indirect

--- a/shrinker/array.go
+++ b/shrinker/array.go
@@ -9,29 +9,29 @@ import (
 // Convergence speed for shrinker is O(n*m), n is array size and m is convergance speed of
 // array elements.
 func Array(val reflect.Value, shrinkers []Shrinker) Shrinker {
-	return func(propertyFailed bool) (reflect.Value, Shrinker, error) {
-		if val.Kind() != reflect.Array {
-			return reflect.Value{}, nil, fmt.Errorf("array shrinker cannot shrink %s", val.Kind().String())
-		}
+	mapperSignature := reflect.FuncOf(
+		[]reflect.Type{val.Slice(0, val.Len()).Type()},
+		[]reflect.Type{val.Type()},
+		false,
+	)
 
+	mapper := reflect.MakeFunc(mapperSignature, func(arg []reflect.Value) []reflect.Value {
 		newArray := reflect.New(val.Type()).Elem()
-		reflect.Copy(newArray, val)
-
-		for index, shrinker := range shrinkers {
-			if shrinker == nil {
-				continue
-			}
-
-			val, shrinker, err := shrinker(propertyFailed)
-			if err != nil {
-				return reflect.Value{}, nil, fmt.Errorf("failed to shrink array element. %w", err)
-			}
-
-			newArray.Index(index).Set(val)
-			shrinkers[index] = shrinker
-			return newArray, Array(newArray, shrinkers), nil
+		for index, slice := 0, arg[0]; index < slice.Len(); index++ {
+			newArray.Index(index).Set(slice.Index(index))
 		}
+		return []reflect.Value{newArray}
+	})
 
-		return val, nil, nil
+	return func(propertyFailed bool) (reflect.Value, Shrinker, error) {
+		switch {
+		case val.Kind() != reflect.Array:
+			return reflect.Value{}, nil, fmt.Errorf("array shrinker cannot shrink %s", val.Kind().String())
+		case val.Len() != len(shrinkers):
+			return reflect.Value{}, nil, fmt.Errorf("size of array must match the number of shrinkers")
+		default:
+			shrinker := sliceElements(val.Slice(0, val.Len()), shrinkers...).Map(val.Type(), mapper.Interface())
+			return shrinker(propertyFailed)
+		}
 	}
 }

--- a/shrinker/map.go
+++ b/shrinker/map.go
@@ -1,0 +1,111 @@
+package shrinker
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/steffnova/go-check/constraints"
+)
+
+type Value struct {
+	Value    reflect.Value
+	Shrinker Shrinker
+}
+
+type MapElement struct {
+	Key   Value
+	Value Value
+}
+
+func Map(val reflect.Value, mapElements []MapElement, limits constraints.Length) Shrinker {
+	return MapSize(val, mapElements, limits).
+		Compose(MapValues(val, mapElements, limits)).
+		Compose(MapKeys(val, mapElements, limits))
+}
+
+func MapSize(val reflect.Value, mapElements []MapElement, limits constraints.Length) Shrinker {
+	mapperSignature := reflect.FuncOf(
+		[]reflect.Type{reflect.TypeOf(mapElements)},
+		[]reflect.Type{val.Type()},
+		false,
+	)
+	mapper := reflect.MakeFunc(mapperSignature, func(args []reflect.Value) (results []reflect.Value) {
+		elements := args[0].Interface().([]MapElement)
+
+		for _, key := range val.MapKeys() {
+			val.SetMapIndex(key, reflect.Value{})
+		}
+		for _, element := range elements {
+			val.SetMapIndex(element.Key.Value, element.Value.Value)
+		}
+		return []reflect.Value{val}
+	})
+
+	return sliceSize(reflect.ValueOf(mapElements), 0, limits).
+		Map(val.Type(), mapper.Interface())
+}
+
+func MapValue(val reflect.Value, element MapElement) Shrinker {
+	if element.Value.Shrinker == nil {
+		return nil
+	}
+
+	return func(propertyFailed bool) (reflect.Value, Shrinker, error) {
+		value, shrinker, err := element.Value.Shrinker(propertyFailed)
+		switch {
+		case err != nil:
+			return reflect.Value{}, nil, fmt.Errorf("failed to shrink map's value: %v. %w", element.Value.Value.Interface(), err)
+		case !val.MapIndex(element.Key.Value).IsValid():
+			return val, nil, nil
+		default:
+			element.Value.Value, element.Value.Shrinker = value, shrinker
+			val.SetMapIndex(element.Key.Value, element.Value.Value)
+			return val, MapValue(val, element), nil
+		}
+	}
+}
+
+func MapValues(val reflect.Value, elements []MapElement, limits constraints.Length) Shrinker {
+	var shrinker Shrinker
+	for _, tempElement := range elements {
+		shrinker = shrinker.Compose(MapValue(val, tempElement))
+	}
+
+	return shrinker
+}
+
+func MapKey(val reflect.Value, element MapElement) Shrinker {
+
+	if element.Key.Shrinker == nil {
+		return nil
+	}
+	element.Value.Value = val.MapIndex(element.Key.Value)
+
+	return func(propertyFailed bool) (reflect.Value, Shrinker, error) {
+		value, shrinker, err := element.Key.Shrinker(propertyFailed)
+		switch {
+		case err != nil:
+			return reflect.Value{}, nil, fmt.Errorf("failed to shrink map's key: %v. %w", element.Key.Value.Interface(), err)
+		case !val.MapIndex(element.Key.Value).IsValid():
+			return val, nil, nil
+		case val.MapIndex(value).IsValid() || reflect.DeepEqual(value, element.Key.Value):
+			element.Key.Shrinker = shrinker
+			return val, MapKey(val, element), nil
+		default:
+			currentValue := val.MapIndex(element.Key.Value)
+			val.SetMapIndex(element.Key.Value, reflect.Value{})
+			val.SetMapIndex(value, currentValue)
+			element.Key.Value, element.Key.Shrinker = value, shrinker
+			return val, MapKey(val, element), nil
+		}
+	}
+}
+
+func MapKeys(val reflect.Value, elements []MapElement, limits constraints.Length) Shrinker {
+	var shrinker Shrinker
+	for _, tempElement := range elements {
+		shrinker = shrinker.Compose(MapKey(val, tempElement))
+	}
+
+	return shrinker
+}


### PR DESCRIPTION
[Problem]

Add shrinker for map type

[Solution]

Improve slice shrinker so it can be used for shrinking maps. Shrinking of
maps must be a consistent process in other words iterrating through map
must always be in the same order as map size, keys and values all need to
be shrinked. Map data is for that reason transformed into a slice.

Shrinking of maps is done in 3 steps:
  - size shrinking
  - key shrinking
  - value shrinking

Size shrinking of map is done by re-using slice shrinking process.
Key shrinking shrinks the values of keys while ensuring that shrinking
process doesn't introduce a key collision within map.

Value shrinking shrinks values of map keys.

Close #26