### PR TITLE
[feature/issues/52] Improve Slice shrinker so it can be used for building other shrinkers

### DIFF
--- a/arbitrary/mapper.go
+++ b/arbitrary/mapper.go
@@ -1,0 +1,15 @@
+package arbitrary
+
+import "reflect"
+
+type mapFn func(reflect.Value) reflect.Value
+
+func Mapper(in, out reflect.Type, mapFn mapFn) interface{} {
+	mapperSignature := reflect.FuncOf([]reflect.Type{in}, []reflect.Type{out}, false)
+
+	mapper := reflect.MakeFunc(mapperSignature, func(arg []reflect.Value) []reflect.Value {
+		return []reflect.Value{mapFn(arg[0])}
+	})
+
+	return mapper.Interface()
+}

--- a/generator/array.go
+++ b/generator/array.go
@@ -23,15 +23,18 @@ func Array(element Arbitrary) Arbitrary {
 
 		return func() (reflect.Value, shrinker.Shrinker) {
 			val := reflect.New(target).Elem()
+			elements := make([]shrinker.Shrink, target.Len())
 
-			shrinkers := make([]shrinker.Shrinker, target.Len())
-			for index := range shrinkers {
-				element, shrinker := generate()
+			for index := range elements {
+				element, s := generate()
 				val.Index(index).Set(element)
-				shrinkers[index] = shrinker
+				elements[index] = shrinker.Shrink{
+					Value:    element,
+					Shrinker: s,
+				}
 			}
 
-			return val, shrinker.Array(val, shrinkers)
+			return val, shrinker.Array(target, elements)
 		}, nil
 	}
 }
@@ -62,14 +65,18 @@ func ArrayFrom(arbs ...Arbitrary) Arbitrary {
 
 		return func() (reflect.Value, shrinker.Shrinker) {
 			val := reflect.New(target).Elem()
-			shrinkers := make([]shrinker.Shrinker, target.Len())
+			elements := make([]shrinker.Shrink, target.Len())
+
 			for index, generator := range generators {
-				element, shrinker := generator()
+				element, s := generator()
 				val.Index(index).Set(element)
-				shrinkers[index] = shrinker
+				elements[index] = shrinker.Shrink{
+					Value:    element,
+					Shrinker: s,
+				}
 			}
 
-			return val, shrinker.Array(val, shrinkers)
+			return val, shrinker.Array(target, elements)
 		}, nil
 	}
 }

--- a/generator/map.go
+++ b/generator/map.go
@@ -35,7 +35,7 @@ func Map(key, value Arbitrary, limits ...constraints.Length) Arbitrary {
 		return func() (reflect.Value, shrinker.Shrinker) {
 			size := r.Int64(int64(constraint.Min), int64(constraint.Max))
 
-			mapElements := []shrinker.MapElement{}
+			mapElements := []shrinker.MapShrink{}
 			val := reflect.MakeMap(target)
 			for index := 0; index < int(size); index++ {
 				key, keyShrinker := generateKey()
@@ -45,12 +45,12 @@ func Map(key, value Arbitrary, limits ...constraints.Length) Arbitrary {
 					continue
 				}
 
-				mapElements = append(mapElements, shrinker.MapElement{
-					Key: shrinker.Value{
+				mapElements = append(mapElements, shrinker.MapShrink{
+					Key: shrinker.Shrink{
 						Value:    key,
 						Shrinker: keyShrinker,
 					},
-					Value: shrinker.Value{
+					Value: shrinker.Shrink{
 						Value:    value,
 						Shrinker: valueShrinker,
 					},

--- a/generator/struct.go
+++ b/generator/struct.go
@@ -38,14 +38,16 @@ func Struct(fieldArbitraries ...map[string]Arbitrary) Arbitrary {
 		return func() (reflect.Value, shrinker.Shrinker) {
 			val := reflect.New(target).Elem()
 
-			shrinkers := make(map[string]shrinker.Shrinker, target.NumField())
+			shrinks := make([]shrinker.Shrink, target.NumField())
 			for index, generator := range generators {
-				fieldName := target.Field(index).Name
-				fieldVal, shrinker := generator()
-				val.FieldByName(fieldName).Set(fieldVal)
-				shrinkers[fieldName] = shrinker
+				fieldValue, fieldShrinker := generator()
+				val.Field(index).Set(fieldValue)
+				shrinks[index] = shrinker.Shrink{
+					Value:    fieldValue,
+					Shrinker: fieldShrinker,
+				}
 			}
-			return val, shrinker.Struct(val, shrinkers)
+			return val, shrinker.Struct(target, shrinks)
 		}, nil
 	}
 }

--- a/shrinker/array.go
+++ b/shrinker/array.go
@@ -3,32 +3,33 @@ package shrinker
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/steffnova/go-check/arbitrary"
 )
 
 // Array is a shrinker for array. Array is shrinked by shrinking it's elements one at a time
 // Convergence speed for shrinker is O(n*m), n is array size and m is convergance speed of
 // array elements.
-func Array(val reflect.Value, shrinkers []Shrinker) Shrinker {
-	mapperSignature := reflect.FuncOf(
-		[]reflect.Type{val.Slice(0, val.Len()).Type()},
-		[]reflect.Type{val.Type()},
-		false,
-	)
-
-	mapper := reflect.MakeFunc(mapperSignature, func(arg []reflect.Value) []reflect.Value {
-		newArray := reflect.New(val.Type()).Elem()
-		for index, slice := 0, arg[0]; index < slice.Len(); index++ {
-			newArray.Index(index).Set(slice.Index(index))
-		}
-		return []reflect.Value{newArray}
-	})
-
+func Array(arrayType reflect.Type, elements []Shrink) Shrinker {
 	switch {
-	case val.Kind() != reflect.Array:
-		return Invalid(fmt.Errorf("array shrinker cannot shrink %s", val.Kind().String()))
-	case val.Len() != len(shrinkers):
-		return Invalid(fmt.Errorf("size of array must match the number of shrinkers"))
+	case arrayType.Kind() != reflect.Array:
+		return Invalid(fmt.Errorf("array shrinker cannot shrink %s", arrayType.Kind().String()))
+	case arrayType.Len() != len(elements):
+		return Invalid(fmt.Errorf("number of shrinkable elements must match size of the array"))
 	default:
-		return sliceElements(val.Slice(0, val.Len()), shrinkers...).Map(mapper.Interface())
+		sliceType := reflect.SliceOf(arrayType.Elem())
+
+		mapFn := func(in reflect.Value) reflect.Value {
+			newArray := reflect.New(arrayType).Elem()
+			for index := 0; index < arrayType.Len(); index++ {
+				newArray.Index(index).Set(in.Index(index))
+			}
+			return newArray
+		}
+
+		return SliceElements(SliceShrink{
+			Type:     reflect.SliceOf(arrayType.Elem()),
+			Elements: elements,
+		}).Map(arbitrary.Mapper(sliceType, arrayType, mapFn))
 	}
 }

--- a/shrinker/shrink.go
+++ b/shrinker/shrink.go
@@ -1,0 +1,26 @@
+package shrinker
+
+import "reflect"
+
+type Shrink struct {
+	Value    reflect.Value
+	Shrinker Shrinker
+}
+
+type SliceShrink struct {
+	Type     reflect.Type
+	Elements []Shrink
+}
+
+func (ss SliceShrink) Value() reflect.Value {
+	val := reflect.MakeSlice(ss.Type, len(ss.Elements), len(ss.Elements))
+	for index, shrink := range ss.Elements {
+		val.Index(index).Set(shrink.Value)
+	}
+	return val
+}
+
+type MapShrink struct {
+	Key   Shrink
+	Value Shrink
+}

--- a/shrinker/shrinker.go
+++ b/shrinker/shrinker.go
@@ -77,19 +77,18 @@ func (shrinker Shrinker) Compose(next Shrinker) Shrinker {
 	}
 }
 
-// WithFallback creates a shrinker that will use shrinker (receiver) if property failed
-// otherwise next is used instead.
-func (shrinker Shrinker) WithFallback(next Shrinker) Shrinker {
+// Or returns a shrinker that uses either shrinker(receiver) or next. Decision is made
+// by evaluating the value of propertyFailed parameter. If property failed, shrinker
+// (receiver) will be used, otherwise next is used instead.
+func (shrinker Shrinker) Or(next Shrinker) Shrinker {
 	if shrinker == nil {
 		return next
 	}
 
 	return func(propertyFailed bool) (reflect.Value, Shrinker, error) {
-		switch {
-		case propertyFailed:
-			return shrinker(true)
-		default:
-			return next(true)
+		if !propertyFailed {
+			return next(!propertyFailed)
 		}
+		return shrinker(propertyFailed)
 	}
 }


### PR DESCRIPTION
[Problem]

Problem is described here: https://github.com/steffnova/go-check/issues/52#issue-1054602054

[Solution]

1. Add Shrink to shrinker package, composite structure of reflect.Value and Shrinker.
Goal is to use Shrink structure to pass information of complex structures,
such as struct, array, slice and map, more easily.

2. Add helper shrink structures for Map and Slice.

3. Add Mapper arbitrary package to more easily define arbitrary mappers
using reflect package.

4. Refactor Slice shrinkers. Slice and SliceElements shrinker have been
reworked.

5. Update Struct, Map and Array shrinkers to use slice shrinkers and Shrink
structure.

Goal of these changes was to reduce code repetition. It also shows how
shrinker for one data structure can be used to build a shrinker for a different
but similar data structure.

Close #52 