### PR TITLE
[feature/issues/54] Improve map shrinker and generator

### DIFF
--- a/arbitrary/filter.go
+++ b/arbitrary/filter.go
@@ -1,0 +1,21 @@
+package arbitrary
+
+import "reflect"
+
+type predicateFn func(reflect.Value) bool
+
+// FilterPredicate returns predicate function that can be used in Filter methods for generators
+// and shrinkers. First parameter in is used to define predicate function signature as input
+// value. Output value is always bool. Second parameter predicateFn is a arbitrary function that
+// defines the behaviour of predicate.
+func FilterPredicate(in reflect.Type, predicate predicateFn) interface{} {
+	boolType := reflect.TypeOf(bool(false))
+	filterSignature := reflect.FuncOf([]reflect.Type{in}, []reflect.Type{boolType}, false)
+
+	filter := reflect.MakeFunc(filterSignature, func(arg []reflect.Value) []reflect.Value {
+		out := predicate(arg[0])
+		return []reflect.Value{reflect.ValueOf(out)}
+	})
+
+	return filter.Interface()
+}

--- a/generator/arbitrary.go
+++ b/generator/arbitrary.go
@@ -29,7 +29,7 @@ func (arb Arbitrary) Map(mapper interface{}) Arbitrary {
 		case val.Type().NumIn() != 1:
 			return nil, fmt.Errorf("mapper must have 1 input value")
 		case val.Type().Out(0).Kind() != target.Kind():
-			return nil, fmt.Errorf("mappers output parameter's kind must match target's kind. Got: %s", target.Kind())
+			return nil, fmt.Errorf("mappers output parameter's kind: %s must match target's kind. Got: %s", val.Type().Out(0).Kind(), target.Kind())
 		}
 
 		generator, err := arb(val.Type().In(0), r)
@@ -70,10 +70,10 @@ func (arb Arbitrary) Filter(predicate interface{}) Arbitrary {
 
 		return func() (reflect.Value, shrinker.Shrinker) {
 			for {
-				val, _ := generate()
+				val, shrinker := generate()
 				outputs := reflect.ValueOf(predicate).Call([]reflect.Value{val})
 				if outputs[0].Bool() {
-					return val.Convert(target), nil
+					return val, shrinker.Filter(val, predicate)
 				}
 			}
 		}, nil

--- a/generator/map.go
+++ b/generator/map.go
@@ -15,6 +15,12 @@ import (
 // is used for defining constraints. Arbitrary will fail to create map Generator
 // if target's reflect.Kind is not Map, fails to create map's key and value
 // Generator or if creation of map's size fails.
+//
+// Note: Generator will always try to create a map within size limits. This
+// means that during key generation it will take into account collision with
+// existing map key's. Pool of values from which keys are generated must have
+// number of unique values equal to map's maximum length value defined by
+// limits parameter, otherwise map generation will be stuck in endless loop.
 func Map(key, value Arbitrary, limits ...constraints.Length) Arbitrary {
 	return func(target reflect.Type, r Random) (Generator, error) {
 		constraint := constraints.LengthDefault()
@@ -35,30 +41,24 @@ func Map(key, value Arbitrary, limits ...constraints.Length) Arbitrary {
 		return func() (reflect.Value, shrinker.Shrinker) {
 			size := r.Int64(int64(constraint.Min), int64(constraint.Max))
 
-			mapElements := []shrinker.MapShrink{}
+			shrinks := [][2]shrinker.Shrink{}
 			val := reflect.MakeMap(target)
+
 			for index := 0; index < int(size); index++ {
 				key, keyShrinker := generateKey()
 				value, valueShrinker := generateValue()
 
-				if val.MapIndex(key).IsValid() {
-					continue
+				for val.MapIndex(key).IsValid() {
+					key, keyShrinker = generateKey()
 				}
 
-				mapElements = append(mapElements, shrinker.MapShrink{
-					Key: shrinker.Shrink{
-						Value:    key,
-						Shrinker: keyShrinker,
-					},
-					Value: shrinker.Shrink{
-						Value:    value,
-						Shrinker: valueShrinker,
-					},
-				})
 				val.SetMapIndex(key, value)
+				shrinks = append(shrinks, [2]shrinker.Shrink{
+					{Value: key, Shrinker: keyShrinker},
+					{Value: value, Shrinker: valueShrinker},
+				})
 			}
-
-			return val, shrinker.Map(val, mapElements, constraint)
+			return val, shrinker.Map(target, shrinks, constraint)
 		}, nil
 	}
 }

--- a/shrinker/shrink.go
+++ b/shrinker/shrink.go
@@ -19,8 +19,3 @@ func (ss SliceShrink) Value() reflect.Value {
 	}
 	return val
 }
-
-type MapShrink struct {
-	Key   Shrink
-	Value Shrink
-}


### PR DESCRIPTION
[Problem]

Map generator should be able to generate a Map within provided size limits
if pool from which key values are generated has number of unique values
within the size limits. Time that it takes can be directly impacted with
the pool of unique values available for keys. In other words collisions
of generated key values should be taken into the account, without taking
a consideration of time required resolving these collisions.
It should also be possible to create maps with fixed size (by using same
value for size's max and min value).

Map shrinker should never shrink map size outside of size limits (which
is not currently the case). The main problem is that during shrinking of
keys, there could be a a key collision in which case map size would be
reduced (because of the multiple elements with the same key).

[Solution]

1. When map generator is generating key values, it takes into an account
all current map element's keys. If generated key is duplicate, key will
be regenerated until a unique value is created.

2. Map shrinker has been refactored. It is now built as a composition of
Slice and Array shrinkers. Map elements are represented as a slice of pairs
(key and value).

3. FilterPredicate function is added to arbitrary package. FilterPredicate
allows creation of arbitrary predicate functions in a runtime using reflect
package.

4. Filter shrinker method is added. It uses predicate function to filter
out shrink values that satisfy it. Filter method for generator.Arbitrary
now uses Shrinker.Filter (previously it didn't have shrinker).

Close #54