### PR TITLE
[feature/issues/56] Add control for bias of generated all Uint values

### DIFF
--- a/check.go
+++ b/check.go
@@ -6,6 +6,8 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/steffnova/go-check/constraints"
 )
 
 var (
@@ -43,7 +45,12 @@ func Check(t *testing.T, property property, config ...Config) {
 	}
 
 	for i := int64(0); i < configuration.Iterations; i++ {
-		if err := run(); err != nil {
+		bias := constraints.Bias{
+			Size:    int(configuration.Iterations),
+			Scaling: int(configuration.Iterations) - int(i),
+		}
+
+		if err := run(bias); err != nil {
 			t.Fatal(
 				fmt.Sprintf("\nCheck failed after %d tests with seed: %d. \n%s", i+1, configuration.Seed, err),
 				fmt.Sprintf("\n\nRe-run:\ngo test -run=%s -seed=%d -iterations=%d", t.Name(), configuration.Seed, configuration.Iterations),

--- a/constraints/bias.go
+++ b/constraints/bias.go
@@ -1,0 +1,21 @@
+package constraints
+
+// Bias contains Size and Scaling properties which are used to scale constraint limits.
+// Scaling factor is calculated by diving Size with Scaling
+type Bias struct {
+	Size    int // Total size of value that should be scaled
+	Scaling int // Defines how much the size is scaled. Range of values: [1, Size]
+}
+
+func biasedFactor(bias Bias, size int) int {
+	switch {
+	case bias.Size >= size+1:
+		return (bias.Scaling * size) / bias.Size
+	case bias.Size == 1:
+		return 0
+	case bias.Scaling == bias.Size:
+		return size
+	default:
+		return (bias.Scaling - 1) * size / (bias.Size - 1)
+	}
+}

--- a/constraints/uint.go
+++ b/constraints/uint.go
@@ -2,6 +2,7 @@ package constraints
 
 import (
 	"math"
+	"math/bits"
 	"strconv"
 )
 
@@ -62,6 +63,23 @@ func Uint32Default() Uint32 {
 type Uint64 struct {
 	Min uint64
 	Max uint64
+}
+
+func (u Uint64) Baised(bias Bias) Uint64 {
+	diff := u.Max - u.Min
+	bitSize := bits.Len64(diff)
+	factor := biasedFactor(bias, bitSize)
+
+	if factor == bitSize {
+		diff = 0
+	} else {
+		diff = diff >> (factor % bitSize)
+	}
+
+	return Uint64{
+		Min: u.Min,
+		Max: u.Min + diff,
+	}
 }
 
 func Uint64Default() Uint64 {

--- a/generator/array.go
+++ b/generator/array.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/steffnova/go-check/constraints"
 	"github.com/steffnova/go-check/shrinker"
 )
 
@@ -21,12 +22,12 @@ func Array(element Arbitrary) Arbitrary {
 			return nil, fmt.Errorf("failed to crete generator. %s", err)
 		}
 
-		return func() (reflect.Value, shrinker.Shrinker) {
+		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
 			val := reflect.New(target).Elem()
 			elements := make([]shrinker.Shrink, target.Len())
 
 			for index := range elements {
-				element, s := generate()
+				element, s := generate(bias)
 				val.Index(index).Set(element)
 				elements[index] = shrinker.Shrink{
 					Value:    element,
@@ -63,12 +64,12 @@ func ArrayFrom(arbs ...Arbitrary) Arbitrary {
 			generators[index] = generator
 		}
 
-		return func() (reflect.Value, shrinker.Shrinker) {
+		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
 			val := reflect.New(target).Elem()
 			elements := make([]shrinker.Shrink, target.Len())
 
 			for index, generator := range generators {
-				element, s := generator()
+				element, s := generator(bias)
 				val.Index(index).Set(element)
 				elements[index] = shrinker.Shrink{
 					Value:    element,

--- a/generator/chan.go
+++ b/generator/chan.go
@@ -22,10 +22,13 @@ func Chan(limits ...constraints.Length) Arbitrary {
 		if target.Kind() != reflect.Chan {
 			return nil, fmt.Errorf("target arbitrary's kind must be Chan. Got: %s", target.Kind())
 		}
-		return func() (reflect.Value, shrinker.Shrinker) {
+		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
 			val := reflect.MakeChan(
 				reflect.ChanOf(reflect.BothDir, target.Elem()),
-				int(r.Int64(int64(constraint.Min), int64(constraint.Max))),
+				int(r.Int64(constraints.Int64{
+					Min: int64(constraint.Min),
+					Max: int64(constraint.Max),
+				})),
 			)
 			return val, nil
 		}, nil

--- a/generator/constant.go
+++ b/generator/constant.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/steffnova/go-check/constraints"
 	"github.com/steffnova/go-check/shrinker"
 )
 
@@ -22,7 +23,7 @@ func Constant(constant interface{}) Arbitrary {
 		case target.Kind() == reflect.TypeOf(constant).Kind():
 			fallthrough
 		case target.Kind() == reflect.Interface && reflect.TypeOf(constant).Implements(target):
-			return func() (reflect.Value, shrinker.Shrinker) {
+			return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
 				return reflect.ValueOf(constant), nil
 			}, nil
 		default:

--- a/generator/float.go
+++ b/generator/float.go
@@ -35,8 +35,8 @@ func Float64(limits ...constraints.Float64) Arbitrary {
 			return nil, fmt.Errorf("lower range value can't be greater then upper range value")
 		}
 
-		return func() (reflect.Value, shrinker.Shrinker) {
-			n := r.Float64(constraint.Min, constraint.Max)
+		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
+			n := r.Float64(constraint)
 			val := reflect.ValueOf(n).Convert(target)
 			return val, shrinker.Float64(val, constraint)
 		}, nil

--- a/generator/func.go
+++ b/generator/func.go
@@ -2,10 +2,10 @@ package generator
 
 import (
 	"fmt"
-	"math"
 	"reflect"
 
 	"github.com/steffnova/go-check/arbitrary"
+	"github.com/steffnova/go-check/constraints"
 	"github.com/steffnova/go-check/shrinker"
 )
 
@@ -35,8 +35,8 @@ func Func(outputs ...Arbitrary) Arbitrary {
 			generators[index] = generator
 			randoms[index] = random
 		}
-		randomInt64 := r.Int64(math.MinInt64, math.MaxInt64)
-		return func() (reflect.Value, shrinker.Shrinker) {
+		randomInt64 := r.Int64(constraints.Int64Default())
+		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
 			fn := reflect.MakeFunc(target, func(inputs []reflect.Value) []reflect.Value {
 				// In order to create 2 different pure functions that have the
 				// same signature but generate different ouput, random value is
@@ -47,7 +47,7 @@ func Func(outputs ...Arbitrary) Arbitrary {
 				outputs := make([]reflect.Value, target.NumOut())
 				for index, generate := range generators {
 					randoms[index].Seed(seed)
-					outputs[index], _ = generate()
+					outputs[index], _ = generate(bias)
 				}
 
 				return outputs

--- a/generator/int.go
+++ b/generator/int.go
@@ -23,8 +23,8 @@ func Int64(limits ...constraints.Int64) Arbitrary {
 		if target.Kind() != reflect.Int64 {
 			return nil, fmt.Errorf("target arbitrary's kind must be Int64. Got: %s", target.Kind())
 		}
-		return func() (reflect.Value, shrinker.Shrinker) {
-			n := r.Int64(constraint.Min, constraint.Max)
+		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
+			n := r.Int64(constraint)
 			nVal := reflect.ValueOf(n).Convert(target)
 			return nVal, shrinker.Int64(nVal, constraint)
 		}, nil

--- a/generator/map.go
+++ b/generator/map.go
@@ -38,18 +38,21 @@ func Map(key, value Arbitrary, limits ...constraints.Length) Arbitrary {
 			return nil, fmt.Errorf("failed to create map's Value generator. %s", err)
 		}
 
-		return func() (reflect.Value, shrinker.Shrinker) {
-			size := r.Int64(int64(constraint.Min), int64(constraint.Max))
+		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
+			size := r.Int64(constraints.Int64{
+				Min: int64(constraint.Min),
+				Max: int64(constraint.Max),
+			})
 
 			shrinks := [][2]shrinker.Shrink{}
 			val := reflect.MakeMap(target)
 
 			for index := 0; index < int(size); index++ {
-				key, keyShrinker := generateKey()
-				value, valueShrinker := generateValue()
+				key, keyShrinker := generateKey(bias)
+				value, valueShrinker := generateValue(bias)
 
 				for val.MapIndex(key).IsValid() {
-					key, keyShrinker = generateKey()
+					key, keyShrinker = generateKey(bias)
 				}
 
 				val.SetMapIndex(key, value)

--- a/generator/nil.go
+++ b/generator/nil.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/steffnova/go-check/constraints"
 	"github.com/steffnova/go-check/shrinker"
 )
 
@@ -14,7 +15,7 @@ func Nil() Arbitrary {
 	return func(target reflect.Type, _ Random) (Generator, error) {
 		switch target.Kind() {
 		case reflect.Chan, reflect.Slice, reflect.Map, reflect.Func, reflect.Interface, reflect.Ptr:
-			return func() (reflect.Value, shrinker.Shrinker) {
+			return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
 				return reflect.Zero(target), nil
 			}, nil
 		default:

--- a/generator/one-from.go
+++ b/generator/one-from.go
@@ -2,6 +2,8 @@ package generator
 
 import (
 	"reflect"
+
+	"github.com/steffnova/go-check/constraints"
 )
 
 // OneFrom is Arbitrary that will create Generator frome one of the passed
@@ -10,7 +12,10 @@ func OneFrom(first Arbitrary, other ...Arbitrary) Arbitrary {
 	return func(target reflect.Type, r Random) (Generator, error) {
 		arbitraries := append([]Arbitrary{first}, other...)
 
-		index := int(r.Int64(0, int64(len(arbitraries)-1)))
+		index := int(r.Int64(constraints.Int64{
+			Min: 0,
+			Max: int64(len(arbitraries) - 1),
+		}))
 		return arbitraries[index](target, r)
 	}
 }

--- a/generator/ptr.go
+++ b/generator/ptr.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/steffnova/go-check/constraints"
 	"github.com/steffnova/go-check/shrinker"
 )
 
@@ -29,8 +30,8 @@ func PtrValid(arb Arbitrary) Arbitrary {
 			return nil, fmt.Errorf("failed to create base generator. %s", err)
 		}
 
-		return func() (reflect.Value, shrinker.Shrinker) {
-			val, valShrinker := generateValue()
+		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
+			val, valShrinker := generateValue(bias)
 			ptr := reflect.New(target.Elem())
 			ptr.Elem().Set(val)
 			return ptr, shrinker.Ptr(ptr, valShrinker)

--- a/generator/random.go
+++ b/generator/random.go
@@ -1,15 +1,17 @@
 package generator
 
+import "github.com/steffnova/go-check/constraints"
+
 // Random is an interface for random number generation
 type Random interface {
 	// Int64 generates random int64 in specifed range [min, max] (inclusive)
-	Int64(min, max int64) int64
+	Int64(constraints.Int64) int64
 
 	// Uint64 generates random uint64 in specified range [min, max] (inclusive)
-	Uint64(min, max uint64) uint64
+	Uint64(constraints.Uint64) uint64
 
 	// Float64 generates random float64 in specifed range [min, max] (inclusive)
-	Float64(min, max float64) float64
+	Float64(constraints.Float64) float64
 
 	// Split returns new Random that can be used idenpendently of original. Random
 	// returned by Split can have it's seed changed without affecting the original

--- a/generator/slice.go
+++ b/generator/slice.go
@@ -29,13 +29,17 @@ func Slice(element Arbitrary, limits ...constraints.Length) Arbitrary {
 			return nil, fmt.Errorf("failed to create generator for slice elements: %s", err)
 		}
 
-		return func() (reflect.Value, shrinker.Shrinker) {
-			size := r.Int64(int64(constraint.Min), int64(constraint.Max))
+		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
+			size := r.Int64(constraints.Int64{
+				Min: int64(constraint.Min),
+				Max: int64(constraint.Max),
+			})
+
 			elements := make([]shrinker.Shrink, size)
 
 			out := reflect.MakeSlice(target, int(size), int(size))
 			for index := range elements {
-				elementValue, elementShrinker := generator()
+				elementValue, elementShrinker := generator(bias)
 				elements[index] = shrinker.Shrink{
 					Value:    elementValue,
 					Shrinker: elementShrinker,

--- a/generator/struct.go
+++ b/generator/struct.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/steffnova/go-check/constraints"
 	"github.com/steffnova/go-check/shrinker"
 )
 
@@ -35,12 +36,12 @@ func Struct(fieldArbitraries ...map[string]Arbitrary) Arbitrary {
 			generators[index] = generate
 		}
 
-		return func() (reflect.Value, shrinker.Shrinker) {
+		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
 			val := reflect.New(target).Elem()
 
 			shrinks := make([]shrinker.Shrink, target.NumField())
 			for index, generator := range generators {
-				fieldValue, fieldShrinker := generator()
+				fieldValue, fieldShrinker := generator(bias)
 				val.Field(index).Set(fieldValue)
 				shrinks[index] = shrinker.Shrink{
 					Value:    fieldValue,

--- a/generator/uint.go
+++ b/generator/uint.go
@@ -22,8 +22,8 @@ func Uint64(limits ...constraints.Uint64) Arbitrary {
 		if target.Kind() != reflect.Uint64 {
 			return nil, fmt.Errorf("target arbitrary's kind must be Uint64. Got: %s", target.Kind())
 		}
-		return func() (reflect.Value, shrinker.Shrinker) {
-			n := r.Uint64(constraint.Min, constraint.Max)
+		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
+			n := r.Uint64(constraint.Baised(bias))
 			nVal := reflect.ValueOf(n).Convert(target)
 			return nVal, shrinker.Uint64(nVal, constraint)
 		}, nil

--- a/property.go
+++ b/property.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/steffnova/go-check/constraints"
 	"github.com/steffnova/go-check/generator"
 	"github.com/steffnova/go-check/shrinker"
 )
@@ -26,7 +27,7 @@ func ErrorForInputs(inputs []reflect.Value) Error {
 	}
 }
 
-type run func() error
+type run func(bias constraints.Bias) error
 
 type property func(generator.Random) (run, error)
 
@@ -53,12 +54,12 @@ func Property(predicate interface{}, arbGenerators ...generator.Arbitrary) prope
 			}
 		}
 
-		return func() error {
+		return func(bias constraints.Bias) error {
 			inputs := make([]reflect.Value, len(generators))
 			shrinkers := make([]shrinker.Shrinker, len(generators))
 
 			for index, generate := range generators {
-				inputs[index], shrinkers[index] = generate()
+				inputs[index], shrinkers[index] = generate(bias)
 			}
 
 			outputs := reflect.ValueOf(predicate).Call(inputs)


### PR DESCRIPTION
[Problem]

Problem is presented [here](https://github.com/steffnova/go-check/issues/56).
It applies to all Uint types: uint, uint8, uint16, uint32, uint64

[Solution]

Add Bias structure. It has two properties size and scaling. Size presents
total size of the generated value, it can be any valid positive int value.
Scaling represents the chunk of the whole size. If size is 100 and scaling
is 1, it represents 1/100th part of the value. For size 100 and scaling 100
it represents the whole value.

Bias is part of Generator input. Uint64 generator will apply bias to defined
limits.

Bias size and scaling corespond to total number of iterations and current
iteration number respectively.

Uint resizing is done by shifting the upper limit by n bits. N is
calculated using the total number of bits required to represent the upper
limit and Bias's size and scaling. Shifting is equivalent of dividing by 2.
This ensures exponential distribution of scaled values.
Maximum number of different factor values is 65 (from 0 to 64).

NOTE: Random interface has been updated to use contraints.Uint64,
constraint.Int64 and constraints.Float64 instead of 2 parameters min and max.

Close #56