### PR TITLE
[feature/issues/58] Add control for bias of generated Int values

### DIFF
--- a/constraints/int.go
+++ b/constraints/int.go
@@ -83,3 +83,28 @@ func Int64Default() Int64 {
 		Max: math.MaxInt64,
 	}
 }
+
+func (i Int64) Biased(bias Bias) Int64 {
+	switch {
+	case i.Min <= 0 && i.Max <= 0:
+		ui := Uint64{Min: uint64(-i.Max), Max: uint64(-i.Min)}.Baised(bias)
+		return Int64{
+			Min: int64(-ui.Max),
+			Max: int64(-ui.Min),
+		}
+	case i.Min >= 0 && i.Max >= 0:
+		ui := Uint64{Min: uint64(i.Min), Max: uint64(i.Max)}.Baised(bias)
+		return Int64{
+			Min: int64(ui.Min),
+			Max: int64(ui.Max),
+		}
+	default:
+		ui1 := Uint64{Min: 0, Max: uint64(-i.Min)}.Baised(bias)
+		ui2 := Uint64{Min: 0, Max: uint64(i.Max)}.Baised(bias)
+		return Int64{
+			Min: int64(-ui1.Max),
+			Max: int64(ui2.Max),
+		}
+	}
+
+}

--- a/generator/int.go
+++ b/generator/int.go
@@ -24,9 +24,11 @@ func Int64(limits ...constraints.Int64) Arbitrary {
 			return nil, fmt.Errorf("target arbitrary's kind must be Int64. Got: %s", target.Kind())
 		}
 		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
-			n := r.Int64(constraint)
+			biasedConstraint := constraint.Biased(bias)
+			n := r.Int64(biasedConstraint)
+			fmt.Println(biasedConstraint)
 			nVal := reflect.ValueOf(n).Convert(target)
-			return nVal, shrinker.Int64(nVal, constraint)
+			return nVal, shrinker.Int64(nVal, biasedConstraint)
 		}, nil
 	}
 }

--- a/generator/uint.go
+++ b/generator/uint.go
@@ -23,9 +23,10 @@ func Uint64(limits ...constraints.Uint64) Arbitrary {
 			return nil, fmt.Errorf("target arbitrary's kind must be Uint64. Got: %s", target.Kind())
 		}
 		return func(bias constraints.Bias) (reflect.Value, shrinker.Shrinker) {
-			n := r.Uint64(constraint.Baised(bias))
+			biasedConstraint := constraint.Baised(bias)
+			n := r.Uint64(biasedConstraint)
 			nVal := reflect.ValueOf(n).Convert(target)
-			return nVal, shrinker.Uint64(nVal, constraint)
+			return nVal, shrinker.Uint64(nVal, biasedConstraint)
 		}, nil
 	}
 }


### PR DESCRIPTION
[Problem]

Problem is presented [here](https://github.com/steffnova/go-check/issues/58).
It applies to all Int types: int, int8, int16, int32, int64

[Solution]

Int resizing is done by using uint resizing done in #56. If constraints.Int64
Min and Max properties are of the same sign they are transformed in
constratins.Uint64. Negative numbers are first inverted into a positives.

If Min and Max have different signs, then constraints are split into to
distinct ones: [Min, 0] and [0, Max]. Positive and Negative side
of constrains are resized independently.

NOTE: Fixed an issue where biased constraints are not passed to Uint64 shrinker

close #58