### PR TITLE
[bugfix/issues/78] Generators fail to generate values for user defined types

### DIFF
--- a/generator/bool.go
+++ b/generator/bool.go
@@ -1,14 +1,28 @@
 package generator
 
-import "github.com/steffnova/go-check/constraints"
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/steffnova/go-check/arbitrary"
+	"github.com/steffnova/go-check/constraints"
+)
 
 // Bool returns generator of bool types. Error is returned if generator's
 // target is not bool type.
 func Bool() Generator {
-	return Uint64(constraints.Uint64{
-		Min: 0,
-		Max: 1,
-	}).Map(func(n int64) bool {
-		return n != 0
-	})
+	return func(target reflect.Type, bias constraints.Bias, r Random) (Generate, error) {
+		switch {
+		case target.Kind() != reflect.Bool:
+			return nil, fmt.Errorf("can't use Bool generator for %s type", target)
+		default:
+			mapper := arbitrary.Mapper(reflect.TypeOf(uint64(0)), target, func(in reflect.Value) reflect.Value {
+				return reflect.ValueOf(in.Uint() != 0).Convert(target)
+			})
+			return Uint64(constraints.Uint64{
+				Min: 0,
+				Max: 1,
+			}).Map(mapper)(target, bias, r)
+		}
+	}
 }

--- a/generator/int.go
+++ b/generator/int.go
@@ -2,7 +2,9 @@ package generator
 
 import (
 	"fmt"
+	"reflect"
 
+	"github.com/steffnova/go-check/arbitrary"
 	"github.com/steffnova/go-check/constraints"
 )
 
@@ -16,49 +18,35 @@ func Int64(limits ...constraints.Int64) Generator {
 		constraint = limits[0]
 	}
 
-	switch {
-	case constraint.Min > constraint.Max:
-		return Invalid(fmt.Errorf("lower limit: %d cannot be greater than upper limit: %d", constraint.Min, constraint.Max))
-	case constraint.Max < 0:
-		return Uint64(constraints.Uint64{Min: uint64(-constraint.Max), Max: uint64(-constraint.Min)}).
-			Map(func(x uint64) int64 {
-				return int64(-x)
-			})
-	case constraint.Min >= 0:
-		return Uint64(constraints.Uint64{Min: uint64(constraint.Min), Max: uint64(constraint.Max)}).
-			Map(func(x uint64) int64 {
-				return int64(x)
-			})
-	default:
-		return Weighted(
-			[]uint64{
-				uint64(-(constraint.Min)),
-				uint64(constraint.Max) + 1,
-			},
-			Uint64(constraints.Uint64{Min: 0, Max: uint64(-constraint.Min)}).
-				Map(func(x uint64) int64 {
-					return int64(-x)
-				}),
-			Uint64(constraints.Uint64{Min: 0, Max: uint64(constraint.Max)}).
-				Map(func(x uint64) int64 {
-					return int64(x)
-				}),
-			// Weighted{
-			// 	Weight: uint(-(constraint.Min)),
-			// 	Gen: Uint64(constraints.Uint64{Min: 0, Max: uint64(-constraint.Min)}).
-			// 		Map(func(x uint64) int64 {
-			// 			return int64(-x)
-			// 		}),
-			// },
-			// Weighted{
-			// 	Weight: uint(constraint.Max) + 1,
-			// 	Gen: Uint64(constraints.Uint64{Min: 0, Max: uint64(constraint.Max)}).
-			// 		Map(func(x uint64) int64 {
-			// 			return int64(x)
-			// 		}),
-			// },
-		)
+	return func(target reflect.Type, bias constraints.Bias, r Random) (Generate, error) {
+		negativeMapper := arbitrary.Mapper(reflect.TypeOf(uint64(0)), target, func(in reflect.Value) reflect.Value {
+			return reflect.ValueOf(int64(-in.Uint())).Convert(target)
+		})
+
+		positiveMapper := arbitrary.Mapper(reflect.TypeOf(uint64(0)), target, func(in reflect.Value) reflect.Value {
+			return reflect.ValueOf(int64(in.Uint())).Convert(target)
+		})
+
+		switch {
+		case constraint.Min > constraint.Max:
+			return nil, fmt.Errorf("lower limit: %d cannot be greater than upper limit: %d", constraint.Min, constraint.Max)
+		case constraint.Max < 0:
+			return Uint64(constraints.Uint64{Min: uint64(-constraint.Max), Max: uint64(-constraint.Min)}).
+				Map(negativeMapper)(target, bias, r)
+		case constraint.Min >= 0:
+			return Uint64(constraints.Uint64{Min: uint64(constraint.Min), Max: uint64(constraint.Max)}).
+				Map(positiveMapper)(target, bias, r)
+		default:
+			return Weighted(
+				[]uint64{uint64(-(constraint.Min)), uint64(constraint.Max) + 1},
+				Uint64(constraints.Uint64{Min: 0, Max: uint64(-constraint.Min)}).
+					Map(negativeMapper),
+				Uint64(constraints.Uint64{Min: 0, Max: uint64(constraint.Max)}).
+					Map(positiveMapper),
+			)(target, bias, r)
+		}
 	}
+
 }
 
 // Int32 returns generator for int32 types. Range of int32 values that can be
@@ -70,10 +58,15 @@ func Int32(limits ...constraints.Int32) Generator {
 	if len(limits) > 0 {
 		constraint = limits[0]
 	}
-	return Int64(constraints.Int64{Min: int64(constraint.Min), Max: int64(constraint.Max)}).
-		Map(func(x int64) int32 {
-			return int32(x)
+	return func(target reflect.Type, bias constraints.Bias, r Random) (Generate, error) {
+		mapper := arbitrary.Mapper(reflect.TypeOf(int64(0)), target, func(in reflect.Value) reflect.Value {
+			return reflect.ValueOf(int32(in.Int())).Convert(target)
 		})
+		return Int64(constraints.Int64{
+			Min: int64(constraint.Min),
+			Max: int64(constraint.Max),
+		}).Map(mapper)(target, bias, r)
+	}
 }
 
 // Int16 returns generator for int16 types. Range of int16 values that can be
@@ -85,10 +78,15 @@ func Int16(limits ...constraints.Int16) Generator {
 	if len(limits) > 0 {
 		constraint = limits[0]
 	}
-	return Int64(constraints.Int64{Min: int64(constraint.Min), Max: int64(constraint.Max)}).
-		Map(func(x int64) int16 {
-			return int16(x)
+	return func(target reflect.Type, bias constraints.Bias, r Random) (Generate, error) {
+		mapper := arbitrary.Mapper(reflect.TypeOf(int64(0)), target, func(in reflect.Value) reflect.Value {
+			return reflect.ValueOf(int16(in.Int())).Convert(target)
 		})
+		return Int64(constraints.Int64{
+			Min: int64(constraint.Min),
+			Max: int64(constraint.Max),
+		}).Map(mapper)(target, bias, r)
+	}
 }
 
 // Int8 returns generator for int8 types. Range of int8 values that can be
@@ -100,10 +98,16 @@ func Int8(limits ...constraints.Int8) Generator {
 	if len(limits) > 0 {
 		constraint = limits[0]
 	}
-	return Int64(constraints.Int64{Min: int64(constraint.Min), Max: int64(constraint.Max)}).
-		Map(func(x int64) int8 {
-			return int8(x)
+
+	return func(target reflect.Type, bias constraints.Bias, r Random) (Generate, error) {
+		mapper := arbitrary.Mapper(reflect.TypeOf(int64(0)), target, func(in reflect.Value) reflect.Value {
+			return reflect.ValueOf(int8(in.Int())).Convert(target)
 		})
+		return Int64(constraints.Int64{
+			Min: int64(constraint.Min),
+			Max: int64(constraint.Max),
+		}).Map(mapper)(target, bias, r)
+	}
 }
 
 // Int returns generator for int types. Range of int values that can be
@@ -116,10 +120,13 @@ func Int(limits ...constraints.Int) Generator {
 		constraint.Min, constraint.Max = limits[0].Min, limits[0].Max
 	}
 
-	return Int64(constraints.Int64{
-		Max: int64(constraint.Max),
-		Min: int64(constraint.Min),
-	}).Map(func(n int64) int {
-		return int(n)
-	})
+	return func(target reflect.Type, bias constraints.Bias, r Random) (Generate, error) {
+		mapper := arbitrary.Mapper(reflect.TypeOf(int64(0)), target, func(in reflect.Value) reflect.Value {
+			return reflect.ValueOf(int(in.Int())).Convert(target)
+		})
+		return Int64(constraints.Int64{
+			Min: int64(constraint.Min),
+			Max: int64(constraint.Max),
+		}).Map(mapper)(target, bias, r)
+	}
 }

--- a/generator/string.go
+++ b/generator/string.go
@@ -1,6 +1,11 @@
 package generator
 
-import "github.com/steffnova/go-check/constraints"
+import (
+	"reflect"
+
+	"github.com/steffnova/go-check/arbitrary"
+	"github.com/steffnova/go-check/constraints"
+)
 
 // String returns generator for string types. Range of slice size is defined by
 // "limits" parameter. If "limits" parameter is not specified default [0, 100]
@@ -12,10 +17,13 @@ func String(limits ...constraints.String) Generator {
 		constraint = limits[0]
 	}
 
-	return Slice(
-		Rune(constraint.Rune),
-		constraint.Length,
-	).Map(func(runes []rune) string {
-		return string(runes)
-	})
+	return func(target reflect.Type, bias constraints.Bias, r Random) (Generate, error) {
+		mapper := arbitrary.Mapper(reflect.TypeOf([]rune{}), target, func(in reflect.Value) reflect.Value {
+			return in.Convert(target)
+		})
+		return Slice(
+			Rune(constraint.Rune),
+			constraint.Length,
+		).Map(mapper)(target, bias, r)
+	}
 }

--- a/generator/uint.go
+++ b/generator/uint.go
@@ -41,12 +41,16 @@ func Uint32(limits ...constraints.Uint32) Generator {
 	if len(limits) > 0 {
 		constraint = limits[0]
 	}
-	return Uint64(constraints.Uint64{
-		Min: uint64(constraint.Min),
-		Max: uint64(constraint.Max),
-	}).Map(func(n uint64) uint32 {
-		return uint32(n)
-	})
+	return func(target reflect.Type, bias constraints.Bias, r Random) (Generate, error) {
+		mapper := arbitrary.Mapper(reflect.TypeOf(uint64(0)), target, func(in reflect.Value) reflect.Value {
+			return reflect.ValueOf(uint32(in.Uint())).Convert(target)
+		})
+		return Uint64(constraints.Uint64{
+			Min: uint64(constraint.Min),
+			Max: uint64(constraint.Max),
+		}).Map(mapper)(target, bias, r)
+	}
+
 }
 
 // Uint16 returns generator for uint16 types. Range of int16 values that can be
@@ -58,12 +62,15 @@ func Uint16(limits ...constraints.Uint16) Generator {
 	if len(limits) > 0 {
 		constraint = limits[0]
 	}
-	return Uint64(constraints.Uint64{
-		Max: uint64(constraint.Max),
-		Min: uint64(constraint.Min),
-	}).Map(func(n uint64) uint16 {
-		return uint16(n)
-	})
+	return func(target reflect.Type, bias constraints.Bias, r Random) (Generate, error) {
+		mapper := arbitrary.Mapper(reflect.TypeOf(uint64(0)), target, func(in reflect.Value) reflect.Value {
+			return reflect.ValueOf(uint16(in.Uint())).Convert(target)
+		})
+		return Uint64(constraints.Uint64{
+			Min: uint64(constraint.Min),
+			Max: uint64(constraint.Max),
+		}).Map(mapper)(target, bias, r)
+	}
 }
 
 // Uint8 returns generator for uint8 types. Range of int8 values that can be
@@ -75,12 +82,15 @@ func Uint8(limits ...constraints.Uint8) Generator {
 	if len(limits) > 0 {
 		constraint = limits[0]
 	}
-	return Uint64(constraints.Uint64{
-		Max: uint64(constraint.Max),
-		Min: uint64(constraint.Min),
-	}).Map(func(n uint64) uint8 {
-		return uint8(n)
-	})
+	return func(target reflect.Type, bias constraints.Bias, r Random) (Generate, error) {
+		mapper := arbitrary.Mapper(reflect.TypeOf(uint64(0)), target, func(in reflect.Value) reflect.Value {
+			return reflect.ValueOf(uint8(in.Uint())).Convert(target)
+		})
+		return Uint64(constraints.Uint64{
+			Min: uint64(constraint.Min),
+			Max: uint64(constraint.Max),
+		}).Map(mapper)(target, bias, r)
+	}
 }
 
 // UInt returns generator for uint types. Range of uint values that can be
@@ -92,11 +102,14 @@ func Uint(limits ...constraints.Uint) Generator {
 	if len(limits) > 0 {
 		constraint = limits[0]
 	}
+	return func(target reflect.Type, bias constraints.Bias, r Random) (Generate, error) {
+		mapper := arbitrary.Mapper(reflect.TypeOf(uint64(0)), target, func(in reflect.Value) reflect.Value {
+			return reflect.ValueOf(uint(in.Uint())).Convert(target)
+		})
 
-	return Uint64(constraints.Uint64{
-		Max: uint64(constraint.Max),
-		Min: uint64(constraint.Min),
-	}).Map(func(n uint64) uint {
-		return uint(n)
-	})
+		return Uint64(constraints.Uint64{
+			Min: uint64(constraint.Min),
+			Max: uint64(constraint.Max),
+		}).Map(mapper)(target, bias, r)
+	}
 }


### PR DESCRIPTION
[Problem]

Generation of values for user defined `int`, `uint`, `bool`
`rune`, `string`, `float` and `complex` types is failing as generators
for these types are not converting base type to it's target type.

The problem is described in full here: #78 

[Solution]

Generators for all mentioned types are now properly converting generated
base value to their target types.

Close #78 