### PR TITLE
🐞 [bugfix/issues/80] Shrinking for Filter combinator not working

### DIFF
--- a/shrinker/map.go
+++ b/shrinker/map.go
@@ -15,8 +15,6 @@ func Map(shrinker Shrinker) Shrinker {
 		switch {
 		case val.Value.Kind() != reflect.Map:
 			return arbitrary.Arbitrary{}, nil, fmt.Errorf("map shrinker cannot shrink %s", val.Value.Kind().String())
-		case val.Value.Len() != len(val.Elements):
-			return arbitrary.Arbitrary{}, nil, fmt.Errorf("number of elements must match size of the map")
 		default:
 			next, shrinker, err := shrinker(val, propertyFailed)
 			if err != nil {

--- a/shrinker/shrinker.go
+++ b/shrinker/shrinker.go
@@ -72,7 +72,7 @@ func (shrinker Shrinker) Filter(defaultValue arbitrary.Arbitrary, predicate inte
 		case nextShrinker == nil:
 			return defaultValue, nil, nil
 		default:
-			return nextShrinker.Filter(defaultValue, predicate)(arb, false)
+			return nextShrinker.Filter(defaultValue, predicate)(shrink, false)
 		}
 	}
 }


### PR DESCRIPTION
[Problem]
Shrinking process breakes when using Filter combinator

[Solution]
Shrinker combinator for Filter, on predicate failure wasn't passing
the last shrink value, but the last value that caused property to fail.
This caused undefined behaviour for shrinking process, thus breaking it

[Note]
Removed error for Map shrinker, number of Arbitrary elements didn't match
the size of the map. This could happen if there are two arbitrary elements
with the same key.