### PR TITLE
🐞[bugfix/issues/88] Complex64 constraints error

### DIFF
--- a/generator/complex.go
+++ b/generator/complex.go
@@ -24,7 +24,7 @@ func Complex128(limits ...constraints.Complex128) Generator {
 			return nil, fmt.Errorf("can't use Complex128 generator for %s type", target)
 		case constraint.Real.Min > constraint.Real.Max:
 			return nil, fmt.Errorf("lower limit of complex's real part can't be higher that it's upper limit")
-		case constraint.Imaginary.Min > constraint.Real.Max:
+		case constraint.Imaginary.Min > constraint.Imaginary.Max:
 			return nil, fmt.Errorf("lower limit of complex's imaginary part can't be higher that it's upper limit")
 		default:
 			mapper := arbitrary.Mapper(reflect.TypeOf([2]float64{}), target, func(in reflect.Value) reflect.Value {
@@ -55,7 +55,7 @@ func Complex64(limits ...constraints.Complex64) Generator {
 			return nil, fmt.Errorf("can't use Complex64 generator for %s type", target)
 		case constraint.Real.Min > constraint.Real.Max:
 			return nil, fmt.Errorf("lower limit of complex's real part can't be higher that it's upper limit")
-		case constraint.Imaginary.Min > constraint.Real.Max:
+		case constraint.Imaginary.Min > constraint.Imaginary.Max:
 			return nil, fmt.Errorf("lower limit of complex's imaginary part can't be higher that it's upper limit")
 		default:
 			mapper := arbitrary.Mapper(reflect.TypeOf([2]float32{}), target, func(in reflect.Value) reflect.Value {


### PR DESCRIPTION
[Problem]
Error is returned when trying to use a Complex64 generator:
```go
generator.Complex64(constraints.Complex64{
    Real: constraints.Float32{
        Min: -3,
        Max: -1,
    },
    Imaginary: constraints.Float32{
        Min: 3,
        Max: 5,
    },
})
```
Generator returns an error: imaginary lower bound higher than upper bound
Issue is present in both Complex64 and Complex128

[Solution]
The issue lies with condition in the [generator itself](https://github.com/steffnova/go-check/blob/63fe3cd00a36e360ddd0d11c286b1a934d5229e6/generator/complex.go#L27)
Complex number's Imaginary Min constraint was compared to Real part's Max

Close #88