### PR TITLE
🤖 [feature/issues/98] Add tests for Uint64 shrinker

### DIFF
--- a/shrinker/uint_test.go
+++ b/shrinker/uint_test.go
@@ -1,0 +1,108 @@
+package shrinker
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/steffnova/go-check/arbitrary"
+	"github.com/steffnova/go-check/constraints"
+)
+
+func TestUint(t *testing.T) {
+	testCase := map[string]func(t *testing.T){
+		"Kind": func(t *testing.T) {
+			arb := arbitrary.Arbitrary{Value: reflect.ValueOf(int(0))}
+			_, _, err := Uint64(constraints.Uint64Default())(arb, false)
+
+			if err == nil {
+				t.Fatalf("Expected error because arb is int and shrinker is Uint64")
+			}
+		},
+		"Constraints": func(t *testing.T) {
+			arb := arbitrary.Arbitrary{Value: reflect.ValueOf(uint64(10))}
+			limits := constraints.Uint64{Max: 2, Min: 10}
+
+			_, _, err := Uint64(limits)(arb, false)
+
+			if err == nil {
+				t.Fatalf("Expected error because limit's upper bound is higher then it's lower bound")
+			}
+		},
+		"NotWithinConstraints": func(t *testing.T) {
+			arb := arbitrary.Arbitrary{Value: reflect.ValueOf(uint64(1))}
+			limits := constraints.Uint64{Max: 20, Min: 10}
+
+			_, _, err := Uint64(limits)(arb, false)
+
+			if err == nil {
+				t.Fatalf("Expected error because limit's upper bound is higher then it's lower bound")
+			}
+		},
+		"Shrink": func(t *testing.T) {
+			arb := arbitrary.Arbitrary{Value: reflect.ValueOf(uint64(50))}
+			limits := constraints.Uint64{Max: 100, Min: 0}
+
+			next, _, err := Uint64(limits)(arb, true)
+
+			if err != nil {
+				t.Fatalf("Unexpected error : %s", err)
+			}
+
+			if next.Value.Uint() > arb.Value.Uint() {
+				t.Fatalf("Shrunk value: %d is bigger then original: %d", next.Value.Uint(), arb.Value.Uint())
+			}
+		},
+		"Unshrink": func(t *testing.T) {
+			arb := arbitrary.Arbitrary{Value: reflect.ValueOf(uint64(50))}
+			limits := constraints.Uint64{Max: 100, Min: 0}
+
+			next, _, err := Uint64(limits)(arb, false)
+
+			if err != nil {
+				t.Fatalf("Unexpected error : %s", err)
+			}
+
+			if next.Value.Uint() < arb.Value.Uint() {
+				t.Fatalf("Shrunk value: %d is smaller then original: %d", next.Value.Uint(), arb.Value.Uint())
+			}
+		},
+		"ShrinkTowardsLowerBound": func(t *testing.T) {
+			arb := arbitrary.Arbitrary{Value: reflect.ValueOf(uint64(50))}
+			limits := constraints.Uint64{Max: 100, Min: 20}
+
+			shrinker := Uint64(limits)
+			for shrinker != nil {
+				var err error
+				arb, shrinker, err = shrinker(arb, true)
+				if err != nil {
+					t.Fatalf("Unexpected error : %s", err)
+				}
+			}
+
+			if arb.Value.Uint() != limits.Min {
+				t.Errorf("Shrunk value: %d should be exactly the value of lower bound limit: %d", arb.Value.Uint(), limits.Min)
+			}
+		},
+		"ShrinkTowardsUpperBound": func(t *testing.T) {
+			arb := arbitrary.Arbitrary{Value: reflect.ValueOf(uint64(50))}
+			limits := constraints.Uint64{Max: 100, Min: 20}
+
+			shrinker := Uint64(limits)
+			for shrinker != nil {
+				var err error
+				arb, shrinker, err = shrinker(arb, false)
+				if err != nil {
+					t.Fatalf("Unexpected error : %s", err)
+				}
+			}
+
+			if arb.Value.Uint() != limits.Max {
+				t.Errorf("Shrunk value: %d should be exactly the value of upper bound limit: %d", arb.Value.Uint(), limits.Max)
+			}
+		},
+	}
+
+	for name, testCase := range testCase {
+		t.Run(name, testCase)
+	}
+}


### PR DESCRIPTION
[Problem]
Uint64 Shrinker is not covered with tests and changes to it could introduce unwanted bugs

[Solution]
Write test that cover all execution paths of Uint64 shrinker, and tests that cover whole shrinking process, either shrinking to upper or lower bound range defined by shrinker's constraints.