### PR TITLE
👷📚🤖[feature/issues/107] Shrinker for Ptr generator

### DIFF
--- a/arbitrary/arbitrary.go
+++ b/arbitrary/arbitrary.go
@@ -105,3 +105,19 @@ func NewStruct(t reflect.Type) func(Arbitrary) Arbitrary {
 		return arb
 	}
 }
+
+func NewPtr(t reflect.Type) func(Arbitrary) Arbitrary {
+	return func(arb Arbitrary) Arbitrary {
+		if len(arb.Elements) == 0 {
+			arb.Value = reflect.Zero(t)
+			return arb
+		}
+
+		if arb.Value.IsZero() || !arb.Value.CanSet() {
+			arb.Value = reflect.New(t.Elem())
+		}
+		arb.Value.Elem().Set(arb.Elements[0].Value)
+
+		return arb
+	}
+}

--- a/constraints/ptr.go
+++ b/constraints/ptr.go
@@ -1,0 +1,11 @@
+package constraints
+
+type Ptr struct {
+	NilFrequency uint64
+}
+
+func PtrDefault() Ptr {
+	return Ptr{
+		NilFrequency: 5,
+	}
+}

--- a/generator/ptr.go
+++ b/generator/ptr.go
@@ -1,35 +1,56 @@
 package generator
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/steffnova/go-check/arbitrary"
 	"github.com/steffnova/go-check/constraints"
+	"github.com/steffnova/go-check/shrinker"
 )
 
-// Ptr is Arbitrary that creates pointer arbitrary.Generator. arbitrary.Generator will return
-// either valid or invalid (nil) pointer for target's type. Error is returned
-// if target's reflect.Kind is not Ptr, or creation of arb's arbitrary.Generator fails.
-func Ptr(arb arbitrary.Generator) arbitrary.Generator {
-	return OneFrom(Nil(), PtrTo(arb))
-}
-
-// PtrTo is Arbitrary that creates pointer arbitrary.Generator. arbitrary.Generator will
-// always return non-nil pointer for target's type. Error is returned
-// if target's reflect.Kind is not Ptr, or creation of arb's arbitrary.Generator
-// fails.
-func PtrTo(arb arbitrary.Generator) arbitrary.Generator {
+// Ptr returns an [arbitrary.Generator] that creates pointer types. The element parameter defines the
+// type to which the pointer points. The limits parameter, even though it is variadic, evaluates only
+// the first instance of [constraints.Ptr]. If limits are omitted, [constraints.PtrDefault] is used
+// instead. [constraints.Ptr.NilFrequency] influences the occurrence of nil pointers:
+//   - NilFrequency of 0 ensures no nil pointers will be generated
+//   - NilFrequency > 0 uses formula 1/NilFrequency.
+//
+// An error is returned if the generator's target parameter is not a pointer or if the element generator
+// returns an error.
+func Ptr(element arbitrary.Generator, limits ...constraints.Ptr) arbitrary.Generator {
+	limit := constraints.PtrDefault()
+	if len(limits) != 0 {
+		limit = limits[0]
+	}
 	return func(target reflect.Type, bias constraints.Bias, r arbitrary.Random) (arbitrary.Arbitrary, error) {
 		if target.Kind() != reflect.Ptr {
-			return arbitrary.Arbitrary{}, arbitrary.NewErrorInvalidTarget(target, "PtrTo")
+			return arbitrary.Arbitrary{}, arbitrary.NewErrorInvalidTarget(target, "Ptr")
 		}
 
-		mapper := arbitrary.Mapper(target.Elem(), target, func(in reflect.Value) reflect.Value {
-			out := reflect.New(target.Elem())
-			out.Elem().Set(in)
-			return out
-		})
+		isNil := limit.NilFrequency != 0 && r.Uint64(constraints.Uint64{Min: 1, Max: limit.NilFrequency})%limit.NilFrequency == 0
 
-		return arb.Map(mapper)(target, bias, r)
+		if isNil {
+			return arbitrary.Arbitrary{
+				Value: reflect.Zero(target),
+			}, nil
+		}
+
+		element, err := element(target.Elem(), bias, r)
+		if err != nil {
+			return arbitrary.Arbitrary{}, fmt.Errorf("failed to generated value pointer: %s points to. %w", target, err)
+		}
+
+		value := reflect.New(target.Elem())
+		value.Elem().Set(element.Value)
+
+		arb := arbitrary.Arbitrary{
+			Value:    value,
+			Elements: arbitrary.Arbitraries{element},
+		}
+		arb.Shrinker = shrinker.Ptr(arb, limit)
+
+		return arb, nil
 	}
+
 }

--- a/generator/ptr_examples_test.go
+++ b/generator/ptr_examples_test.go
@@ -3,12 +3,13 @@ package generator_test
 import (
 	"fmt"
 
+	"github.com/steffnova/go-check/constraints"
 	"github.com/steffnova/go-check/generator"
 )
 
-// This example demonstrates how to use Ptr(Int()) generator for generation of *int values.
-// PtrTo requires a generator for type (int in this example) pointer points to, thus Int()
-// generator is used.
+// This example demonstrates how to use the [Ptr] and [Int] generators to generate *int values.
+// The Ptr generator requires a generator for the type that the pointer points to, so the Int
+// generator is used in this case.
 func ExamplePtr() {
 	streamer := generator.Streamer(
 		func(n *int) {
@@ -25,41 +26,43 @@ func ExamplePtr() {
 		panic(err)
 	}
 	// Output:
-	// -4518808235179270133
+	// 3087144572626463248
 	// -322463145728654719
-	// <nil>
+	// 6634247955539956817
 	// -2122761628320059770
+	// 6925466992496964832
 	// <nil>
 	// 5606570076237929230
-	// -868800358632342511
+	// 5259823212710600989
+	// -1089963290385541773
 	// <nil>
-	// -315038161257240872
-	// -8800248522230157011
 }
 
-// This example demonstrates how to use PtrTo(Int()) generator for generation of *int values.
-// PtrTo requires a generator for type (int in this example) pointer points to, thus Int()
-// generator is used.
-func ExamplePtrTo() {
+// This example demonstrates how to use the [Ptr] and [Uint] generators in conjunction with
+// [constraints.Ptr] to generate non-nil *uint values. By setting NilFrequency to 0, it ensures
+// that nil pointers will never be generated. The [Ptr] generator requires a generator of the
+// type to which the pointer points, so the Uint generator is used in this case.
+
+func ExamplePtr_noNil() {
 	streamer := generator.Streamer(
-		func(n *int) {
+		func(n *uint) {
 			fmt.Printf("%v\n", *n)
 		},
-		generator.PtrTo(generator.Int()),
+		generator.Ptr(generator.Uint(), constraints.Ptr{NilFrequency: 0}),
 	)
 
 	if err := generator.Stream(0, 10, streamer); err != nil {
 		panic(err)
 	}
 	// Output:
-	// -4518808235179270133
-	// -5036824528102830934
-	// 8071137008395949086
-	// -2122761628320059770
-	// 6925466992496964832
-	// 5606570076237929230
-	// -6485228379443441869
-	// -1089963290385541773
-	// -315038161257240872
-	// -8800248522230157011
+	// 4518808235179270133
+	// 3087144572626463248
+	// 7861855757602232086
+	// 12784885724210938115
+	// 2119085704421221023
+	// 1543285579645681342
+	// 15398783846516204029
+	// 9472434474353809100
+	// 3877601997538530707
+	// 16172318933975836041
 }

--- a/generator/ptr_test.go
+++ b/generator/ptr_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/steffnova/go-check/arbitrary"
+	"github.com/steffnova/go-check/constraints"
 )
 
 func TestPtrTo(t *testing.T) {
@@ -12,7 +13,17 @@ func TestPtrTo(t *testing.T) {
 		"InvalidTarget": func(t *testing.T) {
 			err := Stream(0, 10, Streamer(
 				func(int) {},
-				PtrTo(Int()),
+				Ptr(Int()),
+			))
+
+			if !errors.Is(err, arbitrary.ErrorInvalidTarget) {
+				t.Fatalf("Expected error: '%s'", arbitrary.ErrorInvalidTarget)
+			}
+		},
+		"InvalidElementTarget": func(t *testing.T) {
+			err := Stream(0, 10, Streamer(
+				func(*uint) {},
+				Ptr(Int()),
 			))
 
 			if !errors.Is(err, arbitrary.ErrorInvalidTarget) {
@@ -26,7 +37,7 @@ func TestPtrTo(t *testing.T) {
 						t.Fatalf("Nil pointer value generated")
 					}
 				},
-				PtrTo(Int()),
+				Ptr(Int(), constraints.Ptr{NilFrequency: 0}),
 			))
 
 			if err != nil {

--- a/generator/recursive_examples_test.go
+++ b/generator/recursive_examples_test.go
@@ -31,7 +31,7 @@ func ExampleRecursive_binaryTree() {
 				"Value": Int(constraints.Int{Min: 0, Max: 10}),
 				"Left":  r(),
 				"Right": r(),
-			}))
+			}), constraints.Ptr{NilFrequency: 3})
 		}, 3),
 	))
 
@@ -39,11 +39,11 @@ func ExampleRecursive_binaryTree() {
 		panic(fmt.Errorf("Unexpected error: '%s'", err))
 	}
 	// Output:
-	// {Value: 5, Left: nil  Right {Value: 8, Left: nil  Right nil}}
-	// nil
-	// {Value: 7, Left: nil  Right nil}
-	// nil
-	// {Value: 0, Left: nil  Right {Value: 7, Left: {Value: 3, Left: nil  Right nil}  Right nil}}
+	// {Value: 2, Left: nil  Right {Value: 0, Left: nil  Right {Value: 5, Left: nil  Right {Value: 3, Left: nil  Right nil}}}}
+	// {Value: 3, Left: {Value: 1, Left: {Value: 8, Left: {Value: 5, Left: nil  Right nil}  Right nil}  Right {Value: 10, Left: {Value: 2, Left: nil  Right nil}  Right {Value: 5, Left: nil  Right nil}}}  Right nil}
+	// {Value: 9, Left: {Value: 4, Left: {Value: 9, Left: {Value: 1, Left: nil  Right nil}  Right {Value: 7, Left: nil  Right nil}}  Right {Value: 4, Left: {Value: 8, Left: nil  Right nil}  Right nil}}  Right nil}
+	// {Value: 6, Left: {Value: 9, Left: {Value: 7, Left: {Value: 4, Left: nil  Right nil}  Right {Value: 3, Left: nil  Right nil}}  Right nil}  Right {Value: 6, Left: {Value: 4, Left: {Value: 8, Left: nil  Right nil}  Right {Value: 9, Left: nil  Right nil}}  Right {Value: 3, Left: {Value: 0, Left: nil  Right nil}  Right {Value: 7, Left: nil  Right nil}}}}
+	// {Value: 9, Left: {Value: 9, Left: {Value: 8, Left: {Value: 2, Left: nil  Right nil}  Right {Value: 10, Left: nil  Right nil}}  Right {Value: 10, Left: {Value: 0, Left: nil  Right nil}  Right {Value: 10, Left: nil  Right nil}}}  Right {Value: 4, Left: {Value: 3, Left: nil  Right nil}  Right nil}}
 }
 
 func ExampleRecursive_recursiveFunction() {

--- a/generator/recursive_test.go
+++ b/generator/recursive_test.go
@@ -40,11 +40,11 @@ func TestRecursive(t *testing.T) {
 					}
 				},
 				Recursive(func(r Recurse) arbitrary.Generator {
-					return PtrTo(Struct(map[string]arbitrary.Generator{
+					return Ptr(Struct(map[string]arbitrary.Generator{
 						"Value": Int(constraints.Int{Min: 0, Max: 10}),
 						"Left":  r(),
 						"Right": r(),
-					}))
+					}), constraints.Ptr{NilFrequency: 0})
 				}, 0),
 			))
 
@@ -74,11 +74,11 @@ func TestRecursive(t *testing.T) {
 					}
 				},
 				Recursive(func(r Recurse) arbitrary.Generator {
-					return PtrTo(Struct(map[string]arbitrary.Generator{
+					return Ptr(Struct(map[string]arbitrary.Generator{
 						"Value": Int(constraints.Int{Min: 0, Max: 10}),
 						"Left":  r(),
 						"Right": r(),
-					}))
+					}), constraints.Ptr{NilFrequency: 0})
 				}, 5),
 			))
 

--- a/generator/weighted_examples_test.go
+++ b/generator/weighted_examples_test.go
@@ -3,6 +3,7 @@ package generator_test
 import (
 	"fmt"
 
+	"github.com/steffnova/go-check/constraints"
 	"github.com/steffnova/go-check/generator"
 )
 
@@ -24,7 +25,7 @@ func ExampleWeighted() {
 		generator.Weighted(
 			[]uint64{1, 9},
 			generator.Nil(),
-			generator.PtrTo(generator.Uint64()),
+			generator.Ptr(generator.Uint64(), constraints.Ptr{NilFrequency: 0}),
 		),
 	)
 

--- a/shrinker/ptr.go
+++ b/shrinker/ptr.go
@@ -1,0 +1,31 @@
+package shrinker
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/steffnova/go-check/arbitrary"
+	"github.com/steffnova/go-check/constraints"
+)
+
+func Ptr(original arbitrary.Arbitrary, limit constraints.Ptr) arbitrary.Shrinker {
+	if original.Value.Kind() != reflect.Ptr {
+		return Fail(fmt.Errorf("Ptr shrinker can't shrink %s", original.Value.Type()))
+	}
+
+	predicate := arbitrary.FilterPredicate(original.Value.Type(), func(v reflect.Value) bool {
+		if limit.NilFrequency != 0 {
+			return true
+		}
+
+		return !v.IsZero()
+	})
+
+	return Chain(
+		CollectionSizeRemoveFront(0),
+		CollectionOneElement(),
+	).
+		TransformAfter(arbitrary.NewPtr(original.Value.Type())).
+		Filter(predicate)
+
+}

--- a/shrinker/ptr_test.go
+++ b/shrinker/ptr_test.go
@@ -1,0 +1,82 @@
+package shrinker
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/steffnova/go-check/arbitrary"
+	"github.com/steffnova/go-check/constraints"
+)
+
+func TestPtr(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"OriginalNotAPtr": func(t *testing.T) {
+			val := uint64(0)
+			arb := arbitrary.Arbitrary{Value: reflect.ValueOf(val)}
+			shrinker := Ptr(arb, constraints.Ptr{NilFrequency: 5})
+			if _, err := shrinker(arb, true); err == nil {
+				t.Fatalf("Expected error when original arbitrary is not pointer")
+			}
+		},
+		"ShrinkingNotNil": func(t *testing.T) {
+			val := uint64(1000)
+			valPtr := &val
+
+			arb := arbitrary.Arbitrary{
+				Value: reflect.ValueOf(valPtr),
+				Elements: arbitrary.Arbitraries{
+					arbitrary.Arbitrary{
+						Value:    reflect.ValueOf(val),
+						Shrinker: Uint64(constraints.Uint64Default()),
+					},
+				},
+			}
+			arb.Shrinker = Ptr(arb, constraints.Ptr{NilFrequency: 0})
+
+			for arb.Shrinker != nil {
+				var err error
+				arb, err = arb.Shrinker(arb, true)
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+			}
+
+			shrink := arb.Value.Interface().(*uint64)
+
+			if shrink == nil || *shrink != 0 {
+				t.Fatalf("Shrinking failed")
+			}
+		},
+		"ShrinkingNil": func(t *testing.T) {
+			val := uint64(1000)
+			valPtr := &val
+
+			arb := arbitrary.Arbitrary{
+				Value: reflect.ValueOf(valPtr),
+				Elements: arbitrary.Arbitraries{
+					arbitrary.Arbitrary{
+						Value:    reflect.ValueOf(val),
+						Shrinker: Uint64(constraints.Uint64Default()),
+					},
+				},
+			}
+			arb.Shrinker = Ptr(arb, constraints.Ptr{NilFrequency: 5})
+
+			for arb.Shrinker != nil {
+				var err error
+				arb, err = arb.Shrinker(arb, true)
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+			}
+
+			if !arb.Value.IsZero() {
+				t.Fatalf("Shrinking failed")
+			}
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, testCase)
+	}
+}


### PR DESCRIPTION
[Problem]

However Ptr doesn't provide shrinker that can shrink pointer to nil. (it only shrinks the value that it points to).

[Solution]

Add Ptr shrinker. Ptr shrinker treats value that it points as an element. This allows usage of CollectionSizeRemoveFront and CollectionElementOne shrinkers to be used to compose Ptr shrinker.

Ptr and PtrTo have been merged into Ptr generator.

Add constraints.Ptr to control generation of nil values. Add arbitrary.NewPtr function that builds pointer from arbitrary.

[Test]
Update tests to reflect removal of PtrTo generator Add tests for Ptr shrinker

[Docs]
Update documentation for Ptr generator and it's examples

[Note]
Examples for weighted and recursive generator have been updated as well because Ptr generator used int these tests now generates different values

Close #107